### PR TITLE
refactor: 按 SRP 与低耦合原则拆分主进程与渲染层

### DIFF
--- a/electron/app-window.ts
+++ b/electron/app-window.ts
@@ -1,0 +1,89 @@
+import { BrowserWindow } from 'electron'
+import type { WindowMode } from '../src/types'
+
+/** 主窗口的创建、尺寸模式切换，以及发往渲染层的消息通道。 */
+
+interface WindowSize {
+  width: number
+  height: number
+  minWidth: number
+  minHeight: number
+}
+
+export const WINDOW_MODES: Record<WindowMode, WindowSize> = {
+  launcher: { width: 900, height: 560, minWidth: 760, minHeight: 480 },
+  manager: { width: 1380, height: 860, minWidth: 1024, minHeight: 680 },
+}
+
+export function isWindowMode(value: unknown): value is WindowMode {
+  return value === 'launcher' || value === 'manager'
+}
+
+export interface CreateWindowOptions {
+  preloadPath: string
+  iconPath: string
+  /** 开发模式下的 Vite 地址；缺省则加载打包后的 index.html。 */
+  devServerUrl?: string
+  indexPath: string
+  onClosed: () => void
+}
+
+export function createMainWindow(options: CreateWindowOptions): BrowserWindow {
+  const initialSize = WINDOW_MODES.launcher
+  const window = new BrowserWindow({
+    width: initialSize.width,
+    height: initialSize.height,
+    minWidth: initialSize.minWidth,
+    minHeight: initialSize.minHeight,
+    backgroundColor: '#151914',
+    frame: false,
+    hasShadow: true,
+    icon: options.iconPath,
+    title: 'DSH Launcher',
+    show: false,
+    webPreferences: {
+      preload: options.preloadPath,
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  })
+
+  window.setMenuBarVisibility(false)
+  window.once('closed', options.onClosed)
+  window.once('ready-to-show', () => window.show())
+
+  if (options.devServerUrl) {
+    void window.loadURL(options.devServerUrl)
+  } else {
+    void window.loadFile(options.indexPath)
+  }
+  return window
+}
+
+export function applyWindowMode(window: BrowserWindow | null, mode: WindowMode): void {
+  if (!window || window.isDestroyed()) return
+  const size = WINDOW_MODES[mode]
+  if (window.isMaximized()) window.unmaximize()
+  window.setMinimumSize(size.minWidth, size.minHeight)
+  window.setSize(size.width, size.height, true)
+  window.center()
+}
+
+/**
+ * 发往渲染层的单一出口。
+ * 「窗口是否还活着」的判断原本在三处推送逻辑里各写了一遍，这里收敛为一处。
+ */
+export interface RendererChannel {
+  send(channel: string, payload: unknown): void
+}
+
+export function createRendererChannel(getWindow: () => BrowserWindow | null): RendererChannel {
+  return {
+    send(channel, payload) {
+      const window = getWindow()
+      if (!window || window.isDestroyed() || window.webContents.isDestroyed()) return
+      window.webContents.send(channel, payload)
+    },
+  }
+}

--- a/electron/command.ts
+++ b/electron/command.ts
@@ -1,0 +1,65 @@
+import { spawnCommand } from './process'
+
+/**
+ * 「启动子进程 → 转发输出 → 收集输出 → 等待退出码」这套流程原本在
+ * 插件命令和 DSH 本体安装两处各写了一遍。这里抽成单一实现。
+ */
+
+export type OutputLevel = 'info' | 'error'
+
+/** 只描述本模块真正用到的部分，便于测试传入替身。 */
+export interface CommandProcess {
+  stdout: NodeJS.ReadableStream
+  stderr: NodeJS.ReadableStream
+  once(event: 'error', listener: (error: Error) => void): unknown
+  once(event: 'exit', listener: (code: number | null) => void): unknown
+}
+
+export interface CollectOptions {
+  /** 每段输出到达时回调，用于转发到日志面板和进度解析。 */
+  onOutput?: (text: string, level: OutputLevel) => void
+  /** 保留的输出上限（字符数），只保留末尾部分。 */
+  captureLimit?: number
+}
+
+export interface CommandOptions extends CollectOptions {
+  cwd: string
+  env: NodeJS.ProcessEnv
+}
+
+export interface CommandResult {
+  exitCode: number
+  /** 末尾若干字符的合并输出（stdout 与 stderr 按到达顺序）。 */
+  output: string
+}
+
+export const DEFAULT_CAPTURE_LIMIT = 48_000
+
+/** 监听一个已启动的子进程直到退出。子进程报错时 reject。 */
+export function collectCommandOutput(child: CommandProcess, options: CollectOptions = {}): Promise<CommandResult> {
+  const limit = options.captureLimit ?? DEFAULT_CAPTURE_LIMIT
+  let output = ''
+
+  const handle = (level: OutputLevel) => (chunk: Buffer | string) => {
+    const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+    output = `${output}${text}`.slice(-limit)
+    options.onOutput?.(text, level)
+  }
+  child.stdout.on('data', handle('info'))
+  child.stderr.on('data', handle('error'))
+
+  return new Promise<CommandResult>((resolve, reject) => {
+    child.once('error', reject)
+    child.once('exit', code => resolve({ exitCode: code ?? 1, output }))
+  })
+}
+
+/** 启动一条命令并等待它结束。 */
+export async function runCommand(
+  executable: string,
+  args: string[],
+  options: CommandOptions,
+): Promise<CommandResult> {
+  const child = spawnCommand(executable, args, { cwd: options.cwd, env: options.env })
+  return collectCommandOutput(child, options)
+}

--- a/electron/discovery.ts
+++ b/electron/discovery.ts
@@ -1,0 +1,90 @@
+import type { RepositoryResult } from '../src/types'
+import { isDshRepository } from './dsh-install'
+
+/** GitHub 插件目录检索。解析与映射是纯函数，网络调用单独一层。 */
+
+const SEARCH_ENDPOINT = 'https://api.github.com/search/repositories'
+const PLUGIN_TOPIC = 'dsh-plugin'
+const PAGE_SIZE = 30
+
+export type DiscoverySort = 'stars' | 'updated'
+
+/** GitHub Search API 返回的仓库条目中本模块用到的字段。 */
+export interface GitHubRepositoryItem {
+  id: number
+  full_name: string
+  name: string
+  owner: { login: string }
+  description: string | null
+  html_url: string
+  stargazers_count: number
+  language: string | null
+  updated_at: string
+  topics?: string[]
+  default_branch: string
+}
+
+export interface DiscoveryResponse {
+  repositories: RepositoryResult[]
+  totalCount: number
+  rateRemaining?: number
+}
+
+/**
+ * 构造检索式。用户输入会被裁剪到 80 字符并剔除除字母、数字、点、下划线、
+ * 空格和连字符以外的内容，避免注入额外的搜索限定符。
+ */
+export function buildSearchQuery(query: string): string {
+  const normalized = query.trim().replace(/[^\p{L}\p{N}._ -]/gu, ' ').slice(0, 80)
+  return `topic:${PLUGIN_TOPIC}${normalized ? ` ${normalized} in:name,description` : ''}`
+}
+
+export function buildSearchUrl(query: string, sort: DiscoverySort): URL {
+  const url = new URL(SEARCH_ENDPOINT)
+  url.searchParams.set('q', buildSearchQuery(query))
+  url.searchParams.set('sort', sort)
+  url.searchParams.set('order', 'desc')
+  url.searchParams.set('per_page', String(PAGE_SIZE))
+  return url
+}
+
+export function mapRepository(item: GitHubRepositoryItem): RepositoryResult {
+  return {
+    id: item.id,
+    fullName: item.full_name,
+    name: item.name,
+    owner: item.owner.login,
+    description: item.description ?? '此仓库没有提供说明。',
+    url: item.html_url,
+    stars: item.stargazers_count,
+    language: item.language,
+    updatedAt: item.updated_at,
+    topics: item.topics ?? [],
+    defaultBranch: item.default_branch,
+    kind: isDshRepository(item.full_name) ? 'dsh' : 'plugin',
+  }
+}
+
+export function describeSearchFailure(status: number): Error {
+  if (status === 403) return new Error('GitHub 请求额度暂时用尽，请稍后重试。')
+  return new Error(`GitHub 返回 ${status}，暂时无法获取插件。`)
+}
+
+export async function searchPluginRepositories(query: string, sort: DiscoverySort): Promise<DiscoveryResponse> {
+  const response = await fetch(buildSearchUrl(query, sort), {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'DSH-Launcher',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  })
+  if (!response.ok) throw describeSearchFailure(response.status)
+
+  const data = await response.json() as { total_count: number; items: GitHubRepositoryItem[] }
+  const remaining = Number(response.headers.get('x-ratelimit-remaining'))
+  return {
+    repositories: data.items.map(mapRepository),
+    totalCount: data.total_count,
+    rateRemaining: Number.isFinite(remaining) ? remaining : undefined,
+  }
+}

--- a/electron/dsh-install.ts
+++ b/electron/dsh-install.ts
@@ -1,9 +1,9 @@
 import { access, readFile, realpath } from 'node:fs/promises'
 import path from 'node:path'
+import { DSH_PACKAGE_NAME, DSH_REPOSITORY } from '../src/constants'
 import type { DshInstallationStatus, InstallProgress } from '../src/types'
 
-export const DSH_REPOSITORY = 'deepseek-ai/deepseek-harness'
-const DSH_PACKAGE_NAME = '@deepseek-ai/dsh'
+export { DSH_PACKAGE_NAME, DSH_REPOSITORY }
 
 interface DshDetectionOptions {
   managedRoot: string

--- a/electron/installer.ts
+++ b/electron/installer.ts
@@ -1,0 +1,308 @@
+import { existsSync } from 'node:fs'
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { DSH_PACKAGE_NAME } from '../src/constants'
+import type {
+  AppSettings,
+  DshInstallationStatus,
+  InstallProgress,
+  ProfileState,
+  RepositoryInstallResult,
+  RuntimeOutput,
+} from '../src/types'
+import { runCommand, type OutputLevel } from './command'
+import {
+  findInstalledDsh,
+  getManagedDshStatus,
+  installWaitingMessage,
+  isDshRepository,
+  packageManagerProgress,
+} from './dsh-install'
+import { resolveNodeExecutable, type NodeRuntime, type NodeRuntimeProgress } from './node-runtime'
+import { approveIgnoredGitHubBuilds } from './plugin-install'
+import { readProfile } from './profile'
+import { withExecutableDirectoryOnPath } from './process'
+
+/**
+ * 安装编排：插件与 DSH 本体的安装、卸载，以及安装进度的推送。
+ * 同一时刻只允许一个安装任务。
+ */
+
+/**
+ * 拼出调用官方 DSH CLI 的完整参数。
+ * 启动配置可能是 `npx --yes @deepseek-ai/dsh web`，也可能已经绑定到本地 dsh 可执行文件，
+ * 两种情况下 `plugin` 子命令的前缀不同。
+ */
+export function buildPluginCommandArgs(
+  settings: AppSettings,
+  executable: string,
+  args: string[],
+): string[] {
+  const packageIndex = settings.launchArgs.indexOf(DSH_PACKAGE_NAME)
+  const prefix = packageIndex >= 0
+    ? settings.launchArgs.slice(0, packageIndex + 1)
+    : path.basename(executable).toLowerCase().startsWith('dsh')
+      ? []
+      : ['--yes', DSH_PACKAGE_NAME]
+  return [...prefix, 'plugin', '--profile', settings.profileName, ...args]
+}
+
+export interface InstallerOptions {
+  readSettings: () => Promise<AppSettings>
+  saveSettings: (settings: AppSettings) => Promise<AppSettings>
+  /** 确保 Node.js 可用；onProgress 用于把下载进度并入安装进度。 */
+  prepareNodeRuntime: (onProgress?: (progress: NodeRuntimeProgress) => void) => Promise<NodeRuntime>
+  /** 启动器自己管理的 DSH 安装目录。 */
+  managedDshRoot: string
+  emitOutput: (level: RuntimeOutput['level'], text: string) => void
+  emitProgress: (progress: InstallProgress) => void
+  isRuntimeRunning: () => boolean
+}
+
+export interface Installer {
+  /** 安装一个 GitHub 仓库；识别为 DSH 本体时走本体安装流程。 */
+  install(fullName: string): Promise<RepositoryInstallResult>
+  /** 从当前 Profile 中卸载一个插件。 */
+  remove(packageName: string): Promise<ProfileState>
+  detectDsh(): Promise<DshInstallationStatus>
+  isBusy(): boolean
+}
+
+/** Node.js 下载进度映射到安装进度的 5% ~ 17% 区间。 */
+const NODE_RUNTIME_PROGRESS_FLOOR = 5
+const NODE_RUNTIME_PROGRESS_CEILING = 17
+const DOWNLOAD_PROGRESS_FLOOR = 28
+
+export function createInstaller(options: InstallerOptions): Installer {
+  let active: InstallProgress | null = null
+
+  const emit = (progress: InstallProgress) => {
+    active = progress
+    options.emitProgress(progress)
+  }
+
+  const currentPercent = (fallback: number) => active?.percent ?? fallback
+
+  const detectDsh = async (): Promise<DshInstallationStatus> => {
+    const settings = await options.readSettings()
+    return findInstalledDsh({
+      managedRoot: options.managedDshRoot,
+      configuredExecutable: settings.launchExecutable,
+    })
+  }
+
+  /** 准备 Node.js，同时把下载进度折算进当前安装任务的进度条。 */
+  const prepareNode = (repository?: string) => options.prepareNodeRuntime(progress => {
+    if (!repository || !active) return
+    emit({
+      repository,
+      kind: active.kind,
+      phase: 'preparing',
+      percent: Math.min(
+        NODE_RUNTIME_PROGRESS_CEILING,
+        NODE_RUNTIME_PROGRESS_FLOOR + Math.round(progress.percent * 0.12),
+      ),
+      message: progress.message,
+    })
+  })
+
+  /**
+   * 包管理器的输出格式各异，能解析出百分比就用真实进度，
+   * 解析不出来就用「已等待 N 秒」的心跳，避免进度条长时间凝固。
+   */
+  const trackPackageProgress = (repository: string, kind: InstallProgress['kind'], message: string) => {
+    const startedAt = Date.now()
+    let measured = false
+
+    const emitWaiting = () => {
+      if (measured) return
+      emit({
+        repository,
+        kind,
+        phase: 'downloading',
+        percent: Math.max(DOWNLOAD_PROGRESS_FLOOR, currentPercent(DOWNLOAD_PROGRESS_FLOOR)),
+        message: installWaitingMessage(message, Date.now() - startedAt),
+        indeterminate: true,
+      })
+    }
+
+    emitWaiting()
+    const heartbeat = setInterval(emitWaiting, 5_000)
+    heartbeat.unref()
+
+    return {
+      handleOutput: (text: string) => {
+        const parsed = packageManagerProgress(text, currentPercent(DOWNLOAD_PROGRESS_FLOOR))
+        if (!parsed || (parsed.indeterminate && measured)) return
+        if (!parsed.indeterminate) measured = true
+        emit({ repository, kind, phase: 'downloading', ...parsed })
+      },
+      stop: () => clearInterval(heartbeat),
+    }
+  }
+
+  /** 调用官方 DSH CLI 的 plugin 子命令。 */
+  async function runPluginCommand(args: string[], installingRepository?: string, allowBuildRetry = true): Promise<void> {
+    const settings = await options.readSettings()
+    const nodeRuntime = await prepareNode(installingRepository)
+    const executable = resolveNodeExecutable(settings.launchExecutable, nodeRuntime)
+    const commandArgs = buildPluginCommandArgs(settings, executable, args)
+
+    options.emitOutput('info', `插件操作：${args.join(' ')}`)
+    if (installingRepository) {
+      emit({ repository: installingRepository, kind: 'plugin', phase: 'resolving', percent: 18, message: '正在解析插件仓库' })
+    }
+
+    const tracker = installingRepository
+      ? trackPackageProgress(installingRepository, 'plugin', '正在下载并安装插件')
+      : null
+
+    let result
+    try {
+      result = await runCommand(executable, commandArgs, {
+        cwd: settings.workspace,
+        env: withExecutableDirectoryOnPath(nodeRuntime.node, {
+          ...process.env,
+          DSH_HOME: settings.dshHome,
+          FORCE_COLOR: '0',
+        }),
+        onOutput: (text, level: OutputLevel) => {
+          options.emitOutput(level, text)
+          tracker?.handleOutput(text)
+        },
+      })
+    } finally {
+      tracker?.stop()
+    }
+
+    // pnpm 默认拒绝执行依赖里的构建脚本。只为当前正在安装的仓库放行，然后重试一次。
+    if (result.exitCode !== 0 && installingRepository && allowBuildRetry && result.output.includes('ERR_PNPM_IGNORED_BUILDS')) {
+      const workspacePath = path.join(settings.dshHome, 'profiles', settings.profileName, 'pnpm-workspace.yaml')
+      const approved = await approveIgnoredGitHubBuilds(workspacePath, result.output, installingRepository)
+      if (approved.length > 0) {
+        options.emitOutput('info', `已允许当前仓库的 ${approved.length} 个构建脚本，正在自动重试。`)
+        emit({
+          repository: installingRepository,
+          kind: 'plugin',
+          phase: 'configuring',
+          percent: Math.max(82, currentPercent(82)),
+          message: '已确认构建权限，正在重新安装',
+        })
+        return runPluginCommand(args, installingRepository, false)
+      }
+    }
+
+    if (result.exitCode !== 0) throw new Error(`插件操作失败（代码 ${result.exitCode}），请查看运行日志。`)
+    options.emitOutput('success', '插件操作完成。')
+  }
+
+  /** 把 DSH 本体装进启动器自己的运行目录，并把启动命令切过去。 */
+  async function installManagedDsh(repository: string): Promise<RepositoryInstallResult> {
+    if (options.isRuntimeRunning()) throw new Error('请先停止 DSH，再安装或更新本地 DSH。')
+
+    const runtimeRoot = options.managedDshRoot
+    await mkdir(runtimeRoot, { recursive: true })
+    const manifestPath = path.join(runtimeRoot, 'package.json')
+    if (!existsSync(manifestPath)) {
+      await writeFile(manifestPath, `${JSON.stringify({ name: 'dsh-launcher-runtime', private: true }, null, 2)}\n`, 'utf8')
+    }
+
+    const nodeRuntime = await prepareNode(repository)
+    emit({ repository, kind: 'dsh', phase: 'resolving', percent: 18, message: '正在解析 DSH 安装包' })
+
+    const tracker = trackPackageProgress(repository, 'dsh', '正在下载并安装 DSH')
+    let result
+    try {
+      result = await runCommand(nodeRuntime.npm, [
+        'install',
+        '--prefix', runtimeRoot,
+        '--save-exact',
+        '--no-audit',
+        '--no-fund',
+        '--progress=true',
+        `${DSH_PACKAGE_NAME}@latest`,
+      ], {
+        cwd: runtimeRoot,
+        env: withExecutableDirectoryOnPath(nodeRuntime.node, {
+          ...process.env,
+          FORCE_COLOR: '0',
+          NPM_CONFIG_UPDATE_NOTIFIER: 'false',
+        }),
+        onOutput: (text, level: OutputLevel) => {
+          options.emitOutput(level, text)
+          tracker.handleOutput(text)
+        },
+      })
+    } finally {
+      tracker.stop()
+    }
+    if (result.exitCode !== 0) throw new Error(`本地 DSH 安装失败（代码 ${result.exitCode}），请查看运行日志。`)
+
+    emit({ repository, kind: 'dsh', phase: 'configuring', percent: 90, message: '正在切换本地启动命令' })
+    const dshInstallation = await getManagedDshStatus(runtimeRoot)
+    if (!dshInstallation.installed || !dshInstallation.executable) {
+      throw new Error('安装完成，但没有找到本地 DSH 可执行文件。')
+    }
+
+    const settings = await options.saveSettings({
+      ...await options.readSettings(),
+      launchExecutable: dshInstallation.executable,
+      launchArgs: ['web'],
+    })
+    const profile = await readProfile(settings.dshHome, settings.profileName)
+    emit({
+      repository,
+      kind: 'dsh',
+      phase: 'complete',
+      percent: 100,
+      message: `DSH ${dshInstallation.version ?? ''} 已安装`,
+    })
+    return { kind: 'dsh', profile, settings, dshInstallation }
+  }
+
+  return {
+    isBusy: () => active !== null,
+
+    detectDsh,
+
+    async install(fullName: string): Promise<RepositoryInstallResult> {
+      if (active) throw new Error(`正在安装 ${active.repository}，请等待当前任务完成。`)
+      const kind = isDshRepository(fullName) ? 'dsh' : 'plugin'
+      emit({
+        repository: fullName,
+        kind,
+        phase: 'preparing',
+        percent: 5,
+        message: kind === 'dsh' ? '正在准备本地 DSH' : '正在准备安装插件',
+      })
+      try {
+        if (kind === 'dsh') return await installManagedDsh(fullName)
+
+        await runPluginCommand(['add', `github:${fullName}`], fullName)
+        emit({ repository: fullName, kind, phase: 'configuring', percent: 90, message: '正在更新插件配置' })
+        const settings = await options.readSettings()
+        const profile = await readProfile(settings.dshHome, settings.profileName)
+        const dshInstallation = await detectDsh()
+        emit({ repository: fullName, kind, phase: 'complete', percent: 100, message: '插件安装完成' })
+        return { kind, profile, settings, dshInstallation }
+      } catch (error) {
+        emit({
+          repository: fullName,
+          kind,
+          phase: 'error',
+          percent: currentPercent(0),
+          message: error instanceof Error ? error.message : '安装失败',
+        })
+        throw error
+      } finally {
+        active = null
+      }
+    },
+
+    async remove(packageName: string): Promise<ProfileState> {
+      const settings = await options.readSettings()
+      await runPluginCommand(['remove', packageName])
+      return readProfile(settings.dshHome, settings.profileName)
+    },
+  }
+}

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -1,0 +1,114 @@
+import { BrowserWindow, dialog, ipcMain, shell } from 'electron'
+import path from 'node:path'
+import { IPC } from '../src/constants'
+import type { AppSettings, WindowMode } from '../src/types'
+import { isWindowMode } from './app-window'
+import { clearDeepSeekApiKey, getDeepSeekCredentialStatus, setDeepSeekApiKey } from './credentials'
+import { searchPluginRepositories, type DiscoverySort } from './discovery'
+import type { Installer } from './installer'
+import {
+  isSafePackageName,
+  isSafeRepositoryName,
+  readProfile,
+  reorderPlugins,
+  togglePlugin,
+} from './profile'
+import type { RuntimeController } from './runtime'
+import type { SettingsStore } from './settings'
+
+/**
+ * 渲染层能触达主进程的全部入口。
+ * 集中在一处，便于一眼看全攻击面：每个 handler 都先校验入参再进业务逻辑。
+ */
+
+export interface IpcDependencies {
+  settings: SettingsStore
+  runtime: RuntimeController
+  installer: Installer
+  getWindow: () => BrowserWindow | null
+  setWindowMode: (mode: WindowMode) => void
+}
+
+export function registerIpcHandlers(deps: IpcDependencies): void {
+  const { settings, runtime, installer } = deps
+
+  ipcMain.handle(IPC.settingsGet, () => settings.read())
+  ipcMain.handle(IPC.settingsSave, (_event, next: AppSettings) => settings.save(next))
+  ipcMain.handle(IPC.dshDetect, () => installer.detectDsh())
+
+  ipcMain.handle(IPC.credentialStatus, async () => {
+    const current = await settings.read()
+    return getDeepSeekCredentialStatus(current.dshHome)
+  })
+  ipcMain.handle(IPC.credentialSet, async (_event, apiKey: string) => {
+    if (typeof apiKey !== 'string') throw new Error('API Key 格式无效。')
+    const current = await settings.read()
+    return setDeepSeekApiKey(current.dshHome, apiKey)
+  })
+  ipcMain.handle(IPC.credentialClear, async () => {
+    const current = await settings.read()
+    return clearDeepSeekApiKey(current.dshHome)
+  })
+
+  ipcMain.handle(IPC.chooseDirectory, async (_event, kind: 'dshHome' | 'workspace') => {
+    const window = deps.getWindow()
+    if (!window) return null
+    const current = await settings.read()
+    const result = await dialog.showOpenDialog(window, {
+      defaultPath: kind === 'dshHome' ? current.dshHome : current.workspace,
+      properties: ['openDirectory', 'createDirectory'],
+    })
+    return result.canceled ? null : result.filePaths[0]
+  })
+
+  ipcMain.handle(IPC.profileRead, async () => {
+    const current = await settings.read()
+    return readProfile(current.dshHome, current.profileName)
+  })
+  ipcMain.handle(IPC.profileToggle, async (_event, payload: { packageName: string; enabled: boolean }) => {
+    if (!isSafePackageName(payload.packageName)) throw new Error('插件名称无效。')
+    const current = await settings.read()
+    return togglePlugin(current.dshHome, current.profileName, payload.packageName, Boolean(payload.enabled))
+  })
+  ipcMain.handle(IPC.profileReorder, async (_event, packageNames: string[]) => {
+    if (!Array.isArray(packageNames) || packageNames.some(name => !isSafePackageName(name))) {
+      throw new Error('插件顺序无效。')
+    }
+    const current = await settings.read()
+    return reorderPlugins(current.dshHome, current.profileName, packageNames)
+  })
+
+  ipcMain.handle(IPC.pluginsDiscover, async (_event, payload: { query: string; sort: DiscoverySort }) => {
+    const sort: DiscoverySort = payload.sort === 'updated' ? 'updated' : 'stars'
+    const found = await searchPluginRepositories(payload.query ?? '', sort)
+    return { ...found, dshInstallation: await installer.detectDsh() }
+  })
+  ipcMain.handle(IPC.pluginsInstall, async (_event, fullName: string) => {
+    if (!isSafeRepositoryName(fullName)) throw new Error('GitHub 仓库名称无效。')
+    return installer.install(fullName)
+  })
+  ipcMain.handle(IPC.pluginsUninstall, async (_event, packageName: string) => {
+    if (!isSafePackageName(packageName)) throw new Error('插件名称无效。')
+    return installer.remove(packageName)
+  })
+
+  ipcMain.handle(IPC.runtimeState, () => runtime.state())
+  ipcMain.handle(IPC.runtimeStart, () => runtime.start())
+  ipcMain.handle(IPC.runtimeStop, () => runtime.stop())
+
+  ipcMain.handle(IPC.windowSetMode, (_event, mode: WindowMode) => {
+    if (!isWindowMode(mode)) throw new Error('窗口模式无效。')
+    deps.setWindowMode(mode)
+  })
+  ipcMain.handle(IPC.windowClose, () => deps.getWindow()?.close())
+
+  ipcMain.handle(IPC.openExternal, (_event, url: string) => {
+    const parsed = new URL(url)
+    if (!['http:', 'https:'].includes(parsed.protocol)) throw new Error('只允许打开网页链接。')
+    return shell.openExternal(parsed.toString())
+  })
+  ipcMain.handle(IPC.openPath, async (_event, target: string) => {
+    if (!path.isAbsolute(target)) throw new Error('路径无效。')
+    await shell.openPath(target)
+  })
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,637 +1,124 @@
-import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron'
-import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
-import { existsSync } from 'node:fs'
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { app, BrowserWindow, shell } from 'electron'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import type {
-  AppSettings,
-  DiscoveryResult,
-  InstallProgress,
-  RepositoryInstallResult,
-  RepositoryResult,
-  RuntimeOutput,
-  RuntimeState,
-  WindowMode,
-} from '../src/types'
-import {
-  isSafePackageName,
-  isSafeProfileName,
-  isSafeRepositoryName,
-  pathExists,
-  readProfile,
-  reorderPlugins,
-  togglePlugin,
-} from './profile'
-import {
-  clearDeepSeekApiKey,
-  getDeepSeekCredentialStatus,
-  setDeepSeekApiKey,
-} from './credentials'
-import { spawnCommand, withExecutableDirectoryOnPath } from './process'
-import { approveIgnoredGitHubBuilds } from './plugin-install'
-import {
-  findInstalledDsh,
-  getManagedDshStatus,
-  installWaitingMessage,
-  isDshRepository,
-  packageManagerProgress,
-} from './dsh-install'
+import type { RuntimeOutput, WindowMode } from '../src/types'
+import { applyWindowMode, createMainWindow, createRendererChannel } from './app-window'
+import { findInstalledDsh } from './dsh-install'
+import { createInstaller, type Installer } from './installer'
+import { registerIpcHandlers } from './ipc'
 import {
   ensureNodeRuntime,
   findSystemNodeRuntime,
-  requiresNodeRuntime,
-  resolveNodeExecutable,
   type NodeRuntime,
   type NodeRuntimeProgress,
 } from './node-runtime'
+import { createRendererEvents } from './renderer-events'
+import { createRuntimeController, type RuntimeController } from './runtime'
+import { createSettingsStore, defaultSettings, type SettingsStore } from './settings'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
+/**
+ * 应用入口与装配根。
+ * 这里只负责「谁依赖谁」，具体行为都在各自的模块里。
+ */
+
+const moduleDirectory = path.dirname(fileURLToPath(import.meta.url))
+
 let mainWindow: BrowserWindow | null = null
-let runtimeProcess: ChildProcessWithoutNullStreams | null = null
-let runtimeStartedAt: string | null = null
-let runtimeUrl: string | null = null
-let settingsCache: AppSettings | null = null
 let quitAfterRuntimeStops = false
-let activeInstallation: InstallProgress | null = null
 
-const WINDOW_MODES: Record<WindowMode, { width: number; height: number; minWidth: number; minHeight: number }> = {
-  launcher: { width: 900, height: 560, minWidth: 760, minHeight: 480 },
-  manager: { width: 1380, height: 860, minWidth: 1024, minHeight: 680 },
+const getWindow = (): BrowserWindow | null => mainWindow
+const events = createRendererEvents(createRendererChannel(getWindow))
+
+interface Services {
+  settings: SettingsStore
+  runtime: RuntimeController
+  installer: Installer
 }
 
-function managedDshRoot(): string {
-  return path.join(app.getPath('userData'), 'dsh-runtime')
-}
+// app.getPath 依赖 app 就绪，因此服务在 whenReady 之后才装配。
+let services: Services | null = null
 
-function managedNodeRoot(): string {
-  return path.join(app.getPath('userData'), 'node-runtime')
-}
+function createServices(): Services {
+  const userData = app.getPath('userData')
+  const managedDshRoot = path.join(userData, 'dsh-runtime')
+  const managedNodeRoot = path.join(userData, 'node-runtime')
 
-function setWindowMode(mode: WindowMode): void {
-  if (!mainWindow || mainWindow.isDestroyed()) return
-  const size = WINDOW_MODES[mode]
-  if (mainWindow.isMaximized()) mainWindow.unmaximize()
-  mainWindow.setMinimumSize(size.minWidth, size.minHeight)
-  mainWindow.setSize(size.width, size.height, true)
-  mainWindow.center()
-}
-
-function withNodeOnPath(runtime: NodeRuntime, environment: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  return withExecutableDirectoryOnPath(runtime.node, environment)
-}
-
-async function prepareNodeRuntime(channel: RuntimeOutput['channel'], repository?: string): Promise<NodeRuntime> {
-  let lastLogBucket = -1
-  return ensureNodeRuntime(managedNodeRoot(), (progress: NodeRuntimeProgress) => {
-    const bucket = Math.floor(progress.percent / 10)
-    if (bucket !== lastLogBucket || progress.percent === 100) {
-      lastLogBucket = bucket
-      emitOutput(channel, 'info', `${progress.message}（${progress.percent}%）`)
-    }
-    if (repository && activeInstallation) {
-      emitInstallProgress({
-        repository,
-        kind: activeInstallation.kind,
-        phase: 'preparing',
-        percent: Math.min(17, 5 + Math.round(progress.percent * 0.12)),
-        message: progress.message,
-      })
-    }
-  })
-}
-
-function defaultSettings(): AppSettings {
-  return {
-    dshHome: process.env.DSH_HOME || path.join(os.homedir(), '.dsh'),
-    profileName: 'web',
-    workspace: app.getPath('documents'),
-    launchExecutable: findSystemNodeRuntime()?.npx ?? (process.platform === 'win32' ? 'npx.cmd' : 'npx'),
-    launchArgs: ['--yes', '@deepseek-ai/dsh', 'web'],
-    openAfterLaunch: true,
-  }
-}
-
-function settingsPath(): string {
-  return path.join(app.getPath('userData'), 'settings.json')
-}
-
-function usesOnDemandDsh(settings: AppSettings): boolean {
-  const executable = path.basename(settings.launchExecutable).toLowerCase()
-  return (executable === 'npx' || executable === 'npx.cmd') && settings.launchArgs.includes('@deepseek-ai/dsh')
-}
-
-async function getSettings(): Promise<AppSettings> {
-  if (settingsCache) return settingsCache
-  const defaults = defaultSettings()
-  try {
-    const stored = JSON.parse(await readFile(settingsPath(), 'utf8')) as Partial<AppSettings>
-    settingsCache = {
-      ...defaults,
-      ...stored,
-      launchArgs: Array.isArray(stored.launchArgs) ? stored.launchArgs.filter(value => typeof value === 'string') : defaults.launchArgs,
-    }
-  } catch {
-    settingsCache = defaults
-  }
-  if (usesOnDemandDsh(settingsCache)) {
-    const detected = await findInstalledDsh({
-      managedRoot: managedDshRoot(),
-      configuredExecutable: settingsCache.launchExecutable,
-    })
-    if (detected.installed && detected.executable) {
-      settingsCache = { ...settingsCache, launchExecutable: detected.executable, launchArgs: ['web'] }
-    }
-  }
-  return settingsCache
-}
-
-function validateSettings(input: AppSettings): AppSettings {
-  if (!input || typeof input !== 'object') throw new Error('设置格式无效。')
-  if (!isSafeProfileName(input.profileName)) throw new Error('配置名称只能包含字母、数字、点、横线或下划线。')
-  if (!path.isAbsolute(input.dshHome) || !path.isAbsolute(input.workspace)) throw new Error('目录必须使用完整路径。')
-  if (!input.launchExecutable.trim()) throw new Error('启动命令不能为空。')
-  if (!Array.isArray(input.launchArgs) || input.launchArgs.some(value => typeof value !== 'string')) throw new Error('启动参数格式无效。')
-  return {
-    dshHome: input.dshHome,
-    profileName: input.profileName,
-    workspace: input.workspace,
-    launchExecutable: input.launchExecutable.trim(),
-    launchArgs: input.launchArgs,
-    openAfterLaunch: Boolean(input.openAfterLaunch),
-  }
-}
-
-async function saveSettings(input: AppSettings): Promise<AppSettings> {
-  const next = validateSettings(input)
-  await mkdir(path.dirname(settingsPath()), { recursive: true })
-  await writeFile(settingsPath(), `${JSON.stringify(next, null, 2)}\n`, 'utf8')
-  settingsCache = next
-  return next
-}
-
-async function detectDshInstallation() {
-  const settings = await getSettings()
-  return findInstalledDsh({ managedRoot: managedDshRoot(), configuredExecutable: settings.launchExecutable })
-}
-
-function runtimeState(): RuntimeState {
-  return {
-    running: runtimeProcess !== null,
-    pid: runtimeProcess?.pid ?? null,
-    startedAt: runtimeStartedAt,
-    url: runtimeUrl,
-  }
-}
-
-function emitState(): void {
-  if (!mainWindow || mainWindow.isDestroyed() || mainWindow.webContents.isDestroyed()) return
-  mainWindow.webContents.send('runtime:state-changed', runtimeState())
-}
-
-function emitOutput(channel: RuntimeOutput['channel'], level: RuntimeOutput['level'], text: string): void {
-  const normalized = text.replace(/\r\n/g, '\n').trimEnd()
-  if (!normalized) return
-  const output: RuntimeOutput = { channel, level, text: normalized, timestamp: new Date().toISOString() }
-  if (!mainWindow || mainWindow.isDestroyed() || mainWindow.webContents.isDestroyed()) return
-  mainWindow.webContents.send('runtime:output', output)
-}
-
-function emitInstallProgress(progress: InstallProgress): void {
-  activeInstallation = progress
-  if (!mainWindow || mainWindow.isDestroyed() || mainWindow.webContents.isDestroyed()) return
-  mainWindow.webContents.send('plugins:install-progress', progress)
-}
-
-function currentInstallPercent(fallback: number): number {
-  return activeInstallation?.percent ?? fallback
-}
-
-function beginPackageInstallProgress(
-  repository: string,
-  kind: InstallProgress['kind'],
-  message: string,
-): { handleOutput: (text: string) => void; stop: () => void } {
-  const startedAt = Date.now()
-  let hasMeasuredProgress = false
-
-  const emitWaiting = () => {
-    if (hasMeasuredProgress) return
-    emitInstallProgress({
-      repository,
-      kind,
-      phase: 'downloading',
-      percent: Math.max(28, currentInstallPercent(28)),
-      message: installWaitingMessage(message, Date.now() - startedAt),
-      indeterminate: true,
+  /**
+   * 准备 Node.js 运行环境，并把下载进度写进日志。
+   * 进度每跨越 10% 记一条，避免刷屏。
+   */
+  const prepareNodeRuntime = (
+    source: RuntimeOutput['channel'],
+    onProgress?: (progress: NodeRuntimeProgress) => void,
+  ): Promise<NodeRuntime> => {
+    let lastBucket = -1
+    return ensureNodeRuntime(managedNodeRoot, progress => {
+      const bucket = Math.floor(progress.percent / 10)
+      if (bucket !== lastBucket || progress.percent === 100) {
+        lastBucket = bucket
+        events.output(source, 'info', `${progress.message}（${progress.percent}%）`)
+      }
+      onProgress?.(progress)
     })
   }
 
-  emitWaiting()
-  const heartbeat = setInterval(emitWaiting, 5_000)
-  heartbeat.unref()
+  const settings = createSettingsStore({
+    filePath: path.join(userData, 'settings.json'),
+    createDefaults: () => defaultSettings({
+      dshHomeFromEnvironment: process.env.DSH_HOME,
+      homeDirectory: os.homedir(),
+      documentsDirectory: app.getPath('documents'),
+      systemNpx: findSystemNodeRuntime()?.npx,
+    }),
+    detectInstalledDsh: configuredExecutable => findInstalledDsh({
+      managedRoot: managedDshRoot,
+      configuredExecutable,
+    }),
+  })
 
-  return {
-    handleOutput: text => {
-      const parsed = packageManagerProgress(text, currentInstallPercent(28))
-      if (!parsed || (parsed.indeterminate && hasMeasuredProgress)) return
-      if (!parsed.indeterminate) hasMeasuredProgress = true
-      emitInstallProgress({ repository, kind, phase: 'downloading', ...parsed })
-    },
-    stop: () => clearInterval(heartbeat),
-  }
+  const runtime = createRuntimeController({
+    readSettings: () => settings.read(),
+    prepareNodeRuntime: () => prepareNodeRuntime('runtime'),
+    fallbackWorkspace: () => app.getPath('documents'),
+    emitOutput: (level, text) => events.output('runtime', level, text),
+    emitState: state => events.runtimeState(state),
+    openExternal: url => void shell.openExternal(url),
+  })
+
+  const installer = createInstaller({
+    readSettings: () => settings.read(),
+    saveSettings: next => settings.save(next),
+    prepareNodeRuntime: onProgress => prepareNodeRuntime('plugin', onProgress),
+    managedDshRoot,
+    emitOutput: (level, text) => events.output('plugin', level, text),
+    emitProgress: progress => events.installProgress(progress),
+    isRuntimeRunning: () => runtime.isRunning(),
+  })
+
+  return { settings, runtime, installer }
 }
 
-function extractUrl(text: string): string | null {
-  const match = text.match(/https?:\/\/(?:127\.0\.0\.1|localhost)(?::\d+)?(?:\/[^\s]*)?/i)
-  return match?.[0] ?? null
-}
-
-async function startRuntime(): Promise<RuntimeState> {
-  if (runtimeProcess) return runtimeState()
-  const settings = await getSettings()
-  const cwd = (await pathExists(settings.workspace)) ? settings.workspace : app.getPath('documents')
-  let executable = settings.launchExecutable
-  let environment: NodeJS.ProcessEnv = { ...process.env, DSH_HOME: settings.dshHome, FORCE_COLOR: '0' }
-  if (requiresNodeRuntime(executable, settings.launchArgs)) {
-    const nodeRuntime = await prepareNodeRuntime('runtime')
-    executable = resolveNodeExecutable(executable, nodeRuntime)
-    environment = withNodeOnPath(nodeRuntime, environment)
-  }
-  emitOutput('runtime', 'info', `启动：${executable} ${settings.launchArgs.join(' ')}`)
-  emitOutput('runtime', 'info', `工作目录：${cwd}`)
-  const child = spawnCommand(executable, settings.launchArgs, {
-    cwd,
-    env: environment,
-  })
-  runtimeProcess = child
-  runtimeStartedAt = new Date().toISOString()
-  runtimeUrl = null
-  emitState()
-  let stderrOutput = ''
-
-  const handleData = (level: RuntimeOutput['level']) => (chunk: Buffer) => {
-    const text = chunk.toString('utf8')
-    if (level === 'error') stderrOutput = `${stderrOutput}${text}`.slice(-24_000)
-    emitOutput('runtime', level, text)
-    const foundUrl = extractUrl(text)
-    if (foundUrl && foundUrl !== runtimeUrl) {
-      runtimeUrl = foundUrl
-      emitState()
-      if (settings.openAfterLaunch) void shell.openExternal(foundUrl)
-    }
-  }
-  child.stdout.on('data', handleData('info'))
-  child.stderr.on('data', handleData('error'))
-  child.once('error', error => {
-    emitOutput('runtime', 'error', `启动失败：${error.message}`)
-  })
-  child.once('exit', code => {
-    const expected = runtimeProcess === null
-    runtimeProcess = null
-    if (!expected && code !== 0 && stderrOutput.includes('EADDRINUSE')) {
-      emitOutput('runtime', 'error', '本地端口已被其他进程占用。请关闭旧的 DSH 服务，或在启动参数中指定其他端口。')
-    }
-    emitOutput('runtime', code === 0 || expected ? 'success' : 'error', `DSH 已退出（代码 ${code ?? '未知'}）`)
-    emitState()
-  })
-  return runtimeState()
-}
-
-async function stopRuntime(): Promise<RuntimeState> {
-  const child = runtimeProcess
-  if (!child) return runtimeState()
-  runtimeProcess = null
-  if (process.platform === 'win32' && child.pid) {
-    const killer = spawn('taskkill.exe', ['/pid', String(child.pid), '/t', '/f'], { windowsHide: true })
-    await new Promise<void>(resolve => {
-      killer.once('error', () => resolve())
-      killer.once('exit', () => resolve())
-    })
-  } else {
-    child.kill('SIGTERM')
-  }
-  emitOutput('runtime', 'info', '已发送停止请求。')
-  emitState()
-  return runtimeState()
-}
-
-async function runPluginCommand(args: string[], installingRepository?: string, allowBuildRetry = true): Promise<void> {
-  const settings = await getSettings()
-  const nodeRuntime = await prepareNodeRuntime('plugin', installingRepository)
-  const executable = resolveNodeExecutable(settings.launchExecutable, nodeRuntime)
-  const packageIndex = settings.launchArgs.indexOf('@deepseek-ai/dsh')
-  const prefix = packageIndex >= 0
-    ? settings.launchArgs.slice(0, packageIndex + 1)
-    : path.basename(executable).toLowerCase().startsWith('dsh')
-      ? []
-      : ['--yes', '@deepseek-ai/dsh']
-  const commandArgs = [...prefix, 'plugin', '--profile', settings.profileName, ...args]
-  emitOutput('plugin', 'info', `插件操作：${args.join(' ')}`)
-  if (installingRepository) {
-    emitInstallProgress({ repository: installingRepository, kind: 'plugin', phase: 'resolving', percent: 18, message: '正在解析插件仓库' })
-  }
-  const child = spawnCommand(executable, commandArgs, {
-    cwd: settings.workspace,
-    env: withNodeOnPath(nodeRuntime, { ...process.env, DSH_HOME: settings.dshHome, FORCE_COLOR: '0' }),
-  })
-  const progressReporter = installingRepository
-    ? beginPackageInstallProgress(installingRepository, 'plugin', '正在下载并安装插件')
-    : null
-  let commandOutput = ''
-  const handleOutput = (level: RuntimeOutput['level']) => (chunk: Buffer) => {
-    const text = chunk.toString('utf8')
-    commandOutput = `${commandOutput}${text}`.slice(-48_000)
-    emitOutput('plugin', level, text)
-    progressReporter?.handleOutput(text)
-  }
-  child.stdout.on('data', handleOutput('info'))
-  child.stderr.on('data', handleOutput('error'))
-  let exitCode: number
-  try {
-    exitCode = await new Promise<number>((resolve, reject) => {
-      child.once('error', reject)
-      child.once('exit', code => resolve(code ?? 1))
-    })
-  } finally {
-    progressReporter?.stop()
-  }
-  if (exitCode !== 0 && installingRepository && allowBuildRetry && commandOutput.includes('ERR_PNPM_IGNORED_BUILDS')) {
-    const workspacePath = path.join(settings.dshHome, 'profiles', settings.profileName, 'pnpm-workspace.yaml')
-    const approved = await approveIgnoredGitHubBuilds(workspacePath, commandOutput, installingRepository)
-    if (approved.length > 0) {
-      emitOutput('plugin', 'info', `已允许当前仓库的 ${approved.length} 个构建脚本，正在自动重试。`)
-      emitInstallProgress({
-        repository: installingRepository,
-        kind: 'plugin',
-        phase: 'configuring',
-        percent: Math.max(82, currentInstallPercent(82)),
-        message: '已确认构建权限，正在重新安装',
-      })
-      return runPluginCommand(args, installingRepository, false)
-    }
-  }
-  if (exitCode !== 0) throw new Error(`插件操作失败（代码 ${exitCode}），请查看运行日志。`)
-  emitOutput('plugin', 'success', '插件操作完成。')
-}
-
-async function installManagedDsh(repository: string): Promise<RepositoryInstallResult> {
-  if (runtimeProcess) throw new Error('请先停止 DSH，再安装或更新本地 DSH。')
-  const runtimeRoot = managedDshRoot()
-  await mkdir(runtimeRoot, { recursive: true })
-  const manifestPath = path.join(runtimeRoot, 'package.json')
-  if (!existsSync(manifestPath)) {
-    await writeFile(manifestPath, `${JSON.stringify({ name: 'dsh-launcher-runtime', private: true }, null, 2)}\n`, 'utf8')
-  }
-
-  const nodeRuntime = await prepareNodeRuntime('plugin', repository)
-  emitInstallProgress({ repository, kind: 'dsh', phase: 'resolving', percent: 18, message: '正在解析 DSH 安装包' })
-  const child = spawnCommand(nodeRuntime.npm, [
-    'install',
-    '--prefix', runtimeRoot,
-    '--save-exact',
-    '--no-audit',
-    '--no-fund',
-    '--progress=true',
-    '@deepseek-ai/dsh@latest',
-  ], {
-    cwd: runtimeRoot,
-    env: withNodeOnPath(nodeRuntime, { ...process.env, FORCE_COLOR: '0', NPM_CONFIG_UPDATE_NOTIFIER: 'false' }),
-  })
-  const progressReporter = beginPackageInstallProgress(repository, 'dsh', '正在下载并安装 DSH')
-
-  const handleOutput = (level: RuntimeOutput['level']) => (chunk: Buffer) => {
-    const text = chunk.toString('utf8')
-    emitOutput('plugin', level, text)
-    progressReporter.handleOutput(text)
-  }
-  child.stdout.on('data', handleOutput('info'))
-  child.stderr.on('data', handleOutput('error'))
-  let exitCode: number
-  try {
-    exitCode = await new Promise<number>((resolve, reject) => {
-      child.once('error', reject)
-      child.once('exit', code => resolve(code ?? 1))
-    })
-  } finally {
-    progressReporter.stop()
-  }
-  if (exitCode !== 0) throw new Error(`本地 DSH 安装失败（代码 ${exitCode}），请查看运行日志。`)
-
-  emitInstallProgress({ repository, kind: 'dsh', phase: 'configuring', percent: 90, message: '正在切换本地启动命令' })
-  const dshInstallation = await getManagedDshStatus(runtimeRoot)
-  if (!dshInstallation.installed || !dshInstallation.executable) {
-    throw new Error('安装完成，但没有找到本地 DSH 可执行文件。')
-  }
-  const currentSettings = await getSettings()
-  const settings = await saveSettings({
-    ...currentSettings,
-    launchExecutable: dshInstallation.executable,
-    launchArgs: ['web'],
-  })
-  const profile = await readProfile(settings.dshHome, settings.profileName)
-  emitInstallProgress({
-    repository,
-    kind: 'dsh',
-    phase: 'complete',
-    percent: 100,
-    message: `DSH ${dshInstallation.version ?? ''} 已安装`,
-  })
-  return { kind: 'dsh', profile, settings, dshInstallation }
-}
-
-async function installRepository(fullName: string): Promise<RepositoryInstallResult> {
-  if (activeInstallation) throw new Error(`正在安装 ${activeInstallation.repository}，请等待当前任务完成。`)
-  const kind = isDshRepository(fullName) ? 'dsh' : 'plugin'
-  emitInstallProgress({ repository: fullName, kind, phase: 'preparing', percent: 5, message: kind === 'dsh' ? '正在准备本地 DSH' : '正在准备安装插件' })
-  try {
-    if (kind === 'dsh') return await installManagedDsh(fullName)
-    await runPluginCommand(['add', `github:${fullName}`], fullName)
-    emitInstallProgress({ repository: fullName, kind, phase: 'configuring', percent: 90, message: '正在更新插件配置' })
-    const settings = await getSettings()
-    const profile = await readProfile(settings.dshHome, settings.profileName)
-    const dshInstallation = await detectDshInstallation()
-    emitInstallProgress({ repository: fullName, kind, phase: 'complete', percent: 100, message: '插件安装完成' })
-    return { kind, profile, settings, dshInstallation }
-  } catch (error) {
-    emitInstallProgress({
-      repository: fullName,
-      kind,
-      phase: 'error',
-      percent: currentInstallPercent(0),
-      message: error instanceof Error ? error.message : '安装失败',
-    })
-    throw error
-  } finally {
-    activeInstallation = null
-  }
-}
-
-async function discoverPlugins(query: string, sort: 'stars' | 'updated'): Promise<DiscoveryResult> {
-  const normalizedQuery = query.trim().replace(/[^\p{L}\p{N}._ -]/gu, ' ').slice(0, 80)
-  const searchQuery = `topic:dsh-plugin${normalizedQuery ? ` ${normalizedQuery} in:name,description` : ''}`
-  const url = new URL('https://api.github.com/search/repositories')
-  url.searchParams.set('q', searchQuery)
-  url.searchParams.set('sort', sort)
-  url.searchParams.set('order', 'desc')
-  url.searchParams.set('per_page', '30')
-  const response = await fetch(url, {
-    headers: {
-      Accept: 'application/vnd.github+json',
-      'User-Agent': 'DSH-Launcher',
-      'X-GitHub-Api-Version': '2022-11-28',
-    },
-  })
-  if (!response.ok) {
-    if (response.status === 403) throw new Error('GitHub 请求额度暂时用尽，请稍后重试。')
-    throw new Error(`GitHub 返回 ${response.status}，暂时无法获取插件。`)
-  }
-  const data = await response.json() as {
-    total_count: number
-    items: Array<{
-      id: number
-      full_name: string
-      name: string
-      owner: { login: string }
-      description: string | null
-      html_url: string
-      stargazers_count: number
-      language: string | null
-      updated_at: string
-      topics?: string[]
-      default_branch: string
-    }>
-  }
-  const repositories: RepositoryResult[] = data.items.map(item => ({
-    id: item.id,
-    fullName: item.full_name,
-    name: item.name,
-    owner: item.owner.login,
-    description: item.description ?? '此仓库没有提供说明。',
-    url: item.html_url,
-    stars: item.stargazers_count,
-    language: item.language,
-    updatedAt: item.updated_at,
-    topics: item.topics ?? [],
-    defaultBranch: item.default_branch,
-    kind: isDshRepository(item.full_name) ? 'dsh' : 'plugin',
-  }))
-  const remaining = Number(response.headers.get('x-ratelimit-remaining'))
-  return {
-    repositories,
-    totalCount: data.total_count,
-    rateRemaining: Number.isFinite(remaining) ? remaining : undefined,
-    dshInstallation: await detectDshInstallation(),
-  }
-}
-
-function createWindow(): void {
-  const initialSize = WINDOW_MODES.launcher
-  mainWindow = new BrowserWindow({
-    width: initialSize.width,
-    height: initialSize.height,
-    minWidth: initialSize.minWidth,
-    minHeight: initialSize.minHeight,
-    backgroundColor: '#151914',
-    frame: false,
-    hasShadow: true,
-    icon: path.join(__dirname, app.isPackaged ? '../dist/launcher-icon.png' : '../public/launcher-icon.png'),
-    title: 'DSH Launcher',
-    show: false,
-    webPreferences: {
-      preload: path.join(__dirname, 'preload.mjs'),
-      contextIsolation: true,
-      nodeIntegration: false,
-      sandbox: true,
-    },
-  })
-  mainWindow.setMenuBarVisibility(false)
-  mainWindow.once('closed', () => { mainWindow = null })
-  mainWindow.once('ready-to-show', () => mainWindow?.show())
-  if (process.env.VITE_DEV_SERVER_URL) {
-    void mainWindow.loadURL(process.env.VITE_DEV_SERVER_URL)
-  } else {
-    void mainWindow.loadFile(path.join(__dirname, '../dist/index.html'))
-  }
-}
-
-function registerHandlers(): void {
-  ipcMain.handle('settings:get', () => getSettings())
-  ipcMain.handle('settings:save', (_event, settings: AppSettings) => saveSettings(settings))
-  ipcMain.handle('dsh:detect-installation', () => detectDshInstallation())
-  ipcMain.handle('credentials:deepseek-status', async () => {
-    const settings = await getSettings()
-    return getDeepSeekCredentialStatus(settings.dshHome)
-  })
-  ipcMain.handle('credentials:deepseek-set', async (_event, apiKey: string) => {
-    if (typeof apiKey !== 'string') throw new Error('API Key 格式无效。')
-    const settings = await getSettings()
-    return setDeepSeekApiKey(settings.dshHome, apiKey)
-  })
-  ipcMain.handle('credentials:deepseek-clear', async () => {
-    const settings = await getSettings()
-    return clearDeepSeekApiKey(settings.dshHome)
-  })
-  ipcMain.handle('dialog:directory', async (_event, kind: 'dshHome' | 'workspace') => {
-    const settings = await getSettings()
-    const result = await dialog.showOpenDialog(mainWindow!, {
-      defaultPath: kind === 'dshHome' ? settings.dshHome : settings.workspace,
-      properties: ['openDirectory', 'createDirectory'],
-    })
-    return result.canceled ? null : result.filePaths[0]
-  })
-  ipcMain.handle('profile:read', async () => {
-    const settings = await getSettings()
-    return readProfile(settings.dshHome, settings.profileName)
-  })
-  ipcMain.handle('profile:toggle', async (_event, payload: { packageName: string; enabled: boolean }) => {
-    if (!isSafePackageName(payload.packageName)) throw new Error('插件名称无效。')
-    const settings = await getSettings()
-    return togglePlugin(settings.dshHome, settings.profileName, payload.packageName, Boolean(payload.enabled))
-  })
-  ipcMain.handle('profile:reorder', async (_event, packageNames: string[]) => {
-    if (!Array.isArray(packageNames) || packageNames.some(name => !isSafePackageName(name))) throw new Error('插件顺序无效。')
-    const settings = await getSettings()
-    return reorderPlugins(settings.dshHome, settings.profileName, packageNames)
-  })
-  ipcMain.handle('plugins:discover', (_event, payload: { query: string; sort: 'stars' | 'updated' }) => {
-    return discoverPlugins(payload.query ?? '', payload.sort === 'updated' ? 'updated' : 'stars')
-  })
-  ipcMain.handle('plugins:install', async (_event, fullName: string) => {
-    if (!isSafeRepositoryName(fullName)) throw new Error('GitHub 仓库名称无效。')
-    return installRepository(fullName)
-  })
-  ipcMain.handle('plugins:uninstall', async (_event, packageName: string) => {
-    if (!isSafePackageName(packageName)) throw new Error('插件名称无效。')
-    const settings = await getSettings()
-    await runPluginCommand(['remove', packageName])
-    return readProfile(settings.dshHome, settings.profileName)
-  })
-  ipcMain.handle('runtime:state', () => runtimeState())
-  ipcMain.handle('runtime:start', () => startRuntime())
-  ipcMain.handle('runtime:stop', () => stopRuntime())
-  ipcMain.handle('window:set-mode', (_event, mode: WindowMode) => {
-    if (mode !== 'launcher' && mode !== 'manager') throw new Error('窗口模式无效。')
-    setWindowMode(mode)
-  })
-  ipcMain.handle('window:close', () => mainWindow?.close())
-  ipcMain.handle('shell:open-external', (_event, url: string) => {
-    const parsed = new URL(url)
-    if (!['http:', 'https:'].includes(parsed.protocol)) throw new Error('只允许打开网页链接。')
-    return shell.openExternal(parsed.toString())
-  })
-  ipcMain.handle('shell:open-path', async (_event, target: string) => {
-    if (!path.isAbsolute(target)) throw new Error('路径无效。')
-    await shell.openPath(target)
+function openMainWindow(): void {
+  mainWindow = createMainWindow({
+    preloadPath: path.join(moduleDirectory, 'preload.mjs'),
+    iconPath: path.join(moduleDirectory, app.isPackaged ? '../dist/launcher-icon.png' : '../public/launcher-icon.png'),
+    devServerUrl: process.env.VITE_DEV_SERVER_URL,
+    indexPath: path.join(moduleDirectory, '../dist/index.html'),
+    onClosed: () => { mainWindow = null },
   })
 }
 
 app.whenReady().then(() => {
-  registerHandlers()
-  createWindow()
+  services = createServices()
+  registerIpcHandlers({
+    ...services,
+    getWindow,
+    setWindowMode: (mode: WindowMode) => applyWindowMode(mainWindow, mode),
+  })
+  openMainWindow()
   app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+    if (BrowserWindow.getAllWindows().length === 0) openMainWindow()
   })
 })
 
@@ -639,10 +126,12 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit()
 })
 
+// 退出前先结束 DSH，否则子进程会留在后台。
 app.on('before-quit', event => {
-  if (quitAfterRuntimeStops || !runtimeProcess) return
+  const runtime = services?.runtime
+  if (quitAfterRuntimeStops || !runtime?.isRunning()) return
   event.preventDefault()
-  void stopRuntime().finally(() => {
+  void runtime.stop().finally(() => {
     quitAfterRuntimeStops = true
     app.quit()
   })

--- a/electron/node-runtime.ts
+++ b/electron/node-runtime.ts
@@ -23,7 +23,18 @@ type ProgressListener = (progress: NodeRuntimeProgress) => void
 
 let installationPromise: Promise<NodeRuntime> | null = null
 
-function runtimePaths(root: string, managed: boolean): NodeRuntime {
+/**
+ * 可执行文件相对于 root 的两种摆放方式。
+ *
+ * - `bin-directory`：root 本身就是存放可执行文件的目录，例如 PATH 里的 `/usr/bin`。
+ * - `distribution-root`：root 是官方发行包解压后的根目录，例如 `node-v24.19.0-linux-x64/`。
+ *
+ * Windows 上两者一致（zip 与 PATH 目录都是三个文件平铺）；
+ * POSIX 上发行包把可执行文件放在 `bin/` 子目录里，差一层。
+ */
+type RuntimeLayout = 'bin-directory' | 'distribution-root'
+
+function runtimePaths(root: string, managed: boolean, layout: RuntimeLayout): NodeRuntime {
   if (process.platform === 'win32') {
     return {
       root,
@@ -33,11 +44,12 @@ function runtimePaths(root: string, managed: boolean): NodeRuntime {
       managed,
     }
   }
+  const binary = layout === 'distribution-root' ? path.join(root, 'bin') : root
   return {
     root,
-    node: path.join(root, 'node'),
-    npm: path.join(root, 'bin', 'npm'),
-    npx: path.join(root, 'bin', 'npx'),
+    node: path.join(binary, 'node'),
+    npm: path.join(binary, 'npm'),
+    npx: path.join(binary, 'npx'),
     managed,
   }
 }
@@ -54,7 +66,8 @@ export function findSystemNodeRuntime(environment: NodeJS.ProcessEnv = process.e
     entries.unshift(path.join(environment.ProgramFiles ?? 'C:\\Program Files', 'nodejs'))
   }
   for (const entry of entries) {
-    const runtime = runtimePaths(entry.replace(/^"|"$/g, ''), false)
+    // PATH 里的每一项本身就是可执行文件所在的目录。
+    const runtime = runtimePaths(entry.replace(/^"|"$/g, ''), false, 'bin-directory')
     if (isCompleteRuntime(runtime)) return runtime
   }
   return null
@@ -81,7 +94,7 @@ export async function findManagedNodeRuntime(runtimeRoot: string): Promise<NodeR
     .map(entry => entry.name)
     .sort((a, b) => b.localeCompare(a, 'en'))
   for (const directory of directories) {
-    const runtime = runtimePaths(path.join(runtimeRoot, directory), true)
+    const runtime = runtimePaths(path.join(runtimeRoot, directory), true, 'distribution-root')
     if (isCompleteRuntime(runtime)) return runtime
   }
   return null
@@ -137,7 +150,7 @@ async function installManagedNodeRuntime(runtimeRoot: string, onProgress?: Progr
   const archiveName = nodeArchiveName()
   const extractedName = archiveName.slice(0, -4)
   const finalRoot = path.join(runtimeRoot, extractedName)
-  const existing = runtimePaths(finalRoot, true)
+  const existing = runtimePaths(finalRoot, true, 'distribution-root')
   if (isCompleteRuntime(existing)) return existing
 
   const nonce = `${process.pid}-${Date.now()}`
@@ -190,11 +203,11 @@ async function installManagedNodeRuntime(runtimeRoot: string, onProgress?: Progr
     if (exitCode !== 0) throw new Error(`解压 Node.js 运行环境失败：${extractionError.trim() || `代码 ${exitCode}`}`)
 
     const stagedRoot = path.join(stagingRoot, extractedName)
-    const stagedRuntime = runtimePaths(stagedRoot, true)
+    const stagedRuntime = runtimePaths(stagedRoot, true, 'distribution-root')
     if (!isCompleteRuntime(stagedRuntime)) throw new Error('Node.js 运行环境解压后文件不完整。')
     await rm(finalRoot, { recursive: true, force: true })
     await rename(stagedRoot, finalRoot)
-    const installed = runtimePaths(finalRoot, true)
+    const installed = runtimePaths(finalRoot, true, 'distribution-root')
     await rm(archivePath, { force: true })
     onProgress?.({ percent: 100, message: `Node.js ${NODE_RUNTIME_VERSION} 已就绪` })
     return installed

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,42 +1,43 @@
 import { contextBridge, ipcRenderer } from 'electron'
+import { IPC, IPC_EVENTS } from '../src/constants'
 import type { AppSettings, InstallProgress, LauncherApi, RuntimeOutput, RuntimeState, WindowMode } from '../src/types'
 
+/**
+ * 渲染层与主进程之间唯一的桥。
+ * 通道名来自共享常量，与主进程的注册面是同一份定义。
+ */
+
+/** 订阅一个主进程推送的事件，返回退订函数。 */
+function subscribe<T>(channel: string, listener: (payload: T) => void): () => void {
+  const wrapped = (_event: Electron.IpcRendererEvent, payload: T) => listener(payload)
+  ipcRenderer.on(channel, wrapped)
+  return () => ipcRenderer.removeListener(channel, wrapped)
+}
+
 const api: LauncherApi = {
-  getSettings: () => ipcRenderer.invoke('settings:get'),
-  saveSettings: (settings: AppSettings) => ipcRenderer.invoke('settings:save', settings),
-  detectDshInstallation: () => ipcRenderer.invoke('dsh:detect-installation'),
-  getDeepSeekCredentialStatus: () => ipcRenderer.invoke('credentials:deepseek-status'),
-  setDeepSeekApiKey: apiKey => ipcRenderer.invoke('credentials:deepseek-set', apiKey),
-  clearDeepSeekApiKey: () => ipcRenderer.invoke('credentials:deepseek-clear'),
-  chooseDirectory: kind => ipcRenderer.invoke('dialog:directory', kind),
-  readProfile: () => ipcRenderer.invoke('profile:read'),
-  togglePlugin: (packageName, enabled) => ipcRenderer.invoke('profile:toggle', { packageName, enabled }),
-  reorderPlugins: packageNames => ipcRenderer.invoke('profile:reorder', packageNames),
-  discoverPlugins: (query, sort) => ipcRenderer.invoke('plugins:discover', { query, sort }),
-  installPlugin: fullName => ipcRenderer.invoke('plugins:install', fullName),
-  uninstallPlugin: packageName => ipcRenderer.invoke('plugins:uninstall', packageName),
-  getRuntimeState: () => ipcRenderer.invoke('runtime:state'),
-  startRuntime: () => ipcRenderer.invoke('runtime:start'),
-  stopRuntime: () => ipcRenderer.invoke('runtime:stop'),
-  openExternal: url => ipcRenderer.invoke('shell:open-external', url),
-  openPath: path => ipcRenderer.invoke('shell:open-path', path),
-  setWindowMode: (mode: WindowMode) => ipcRenderer.invoke('window:set-mode', mode),
-  closeWindow: () => ipcRenderer.invoke('window:close'),
-  onRuntimeOutput: listener => {
-    const wrapped = (_event: Electron.IpcRendererEvent, output: RuntimeOutput) => listener(output)
-    ipcRenderer.on('runtime:output', wrapped)
-    return () => ipcRenderer.removeListener('runtime:output', wrapped)
-  },
-  onRuntimeState: listener => {
-    const wrapped = (_event: Electron.IpcRendererEvent, state: RuntimeState) => listener(state)
-    ipcRenderer.on('runtime:state-changed', wrapped)
-    return () => ipcRenderer.removeListener('runtime:state-changed', wrapped)
-  },
-  onInstallProgress: listener => {
-    const wrapped = (_event: Electron.IpcRendererEvent, progress: InstallProgress) => listener(progress)
-    ipcRenderer.on('plugins:install-progress', wrapped)
-    return () => ipcRenderer.removeListener('plugins:install-progress', wrapped)
-  },
+  getSettings: () => ipcRenderer.invoke(IPC.settingsGet),
+  saveSettings: (settings: AppSettings) => ipcRenderer.invoke(IPC.settingsSave, settings),
+  detectDshInstallation: () => ipcRenderer.invoke(IPC.dshDetect),
+  getDeepSeekCredentialStatus: () => ipcRenderer.invoke(IPC.credentialStatus),
+  setDeepSeekApiKey: apiKey => ipcRenderer.invoke(IPC.credentialSet, apiKey),
+  clearDeepSeekApiKey: () => ipcRenderer.invoke(IPC.credentialClear),
+  chooseDirectory: kind => ipcRenderer.invoke(IPC.chooseDirectory, kind),
+  readProfile: () => ipcRenderer.invoke(IPC.profileRead),
+  togglePlugin: (packageName, enabled) => ipcRenderer.invoke(IPC.profileToggle, { packageName, enabled }),
+  reorderPlugins: packageNames => ipcRenderer.invoke(IPC.profileReorder, packageNames),
+  discoverPlugins: (query, sort) => ipcRenderer.invoke(IPC.pluginsDiscover, { query, sort }),
+  installPlugin: fullName => ipcRenderer.invoke(IPC.pluginsInstall, fullName),
+  uninstallPlugin: packageName => ipcRenderer.invoke(IPC.pluginsUninstall, packageName),
+  getRuntimeState: () => ipcRenderer.invoke(IPC.runtimeState),
+  startRuntime: () => ipcRenderer.invoke(IPC.runtimeStart),
+  stopRuntime: () => ipcRenderer.invoke(IPC.runtimeStop),
+  openExternal: url => ipcRenderer.invoke(IPC.openExternal, url),
+  openPath: path => ipcRenderer.invoke(IPC.openPath, path),
+  setWindowMode: (mode: WindowMode) => ipcRenderer.invoke(IPC.windowSetMode, mode),
+  closeWindow: () => ipcRenderer.invoke(IPC.windowClose),
+  onRuntimeOutput: listener => subscribe<RuntimeOutput>(IPC_EVENTS.runtimeOutput, listener),
+  onRuntimeState: listener => subscribe<RuntimeState>(IPC_EVENTS.runtimeStateChanged, listener),
+  onInstallProgress: listener => subscribe<InstallProgress>(IPC_EVENTS.installProgress, listener),
 }
 
 contextBridge.exposeInMainWorld('launcher', api)

--- a/electron/renderer-events.ts
+++ b/electron/renderer-events.ts
@@ -1,0 +1,36 @@
+import { IPC_EVENTS } from '../src/constants'
+import type { InstallProgress, RuntimeOutput, RuntimeState } from '../src/types'
+import type { RendererChannel } from './app-window'
+
+/** 主进程主动推送给渲染层的三类事件，统一在这里成形与发送。 */
+
+/** 子进程输出里 CRLF 与尾部空白会让日志面板出现空行。 */
+export function normalizeOutputText(text: string): string {
+  return text.replace(/\r\n/g, '\n').trimEnd()
+}
+
+export interface RendererEvents {
+  output(source: RuntimeOutput['channel'], level: RuntimeOutput['level'], text: string): void
+  runtimeState(state: RuntimeState): void
+  installProgress(progress: InstallProgress): void
+}
+
+export function createRendererEvents(
+  channel: RendererChannel,
+  timestamp: () => string = () => new Date().toISOString(),
+): RendererEvents {
+  return {
+    output(source, level, text) {
+      const normalized = normalizeOutputText(text)
+      if (!normalized) return
+      const payload: RuntimeOutput = { channel: source, level, text: normalized, timestamp: timestamp() }
+      channel.send(IPC_EVENTS.runtimeOutput, payload)
+    },
+    runtimeState(state) {
+      channel.send(IPC_EVENTS.runtimeStateChanged, state)
+    },
+    installProgress(progress) {
+      channel.send(IPC_EVENTS.installProgress, progress)
+    },
+  }
+}

--- a/electron/runtime.ts
+++ b/electron/runtime.ts
@@ -1,0 +1,136 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import type { AppSettings, RuntimeOutput, RuntimeState } from '../src/types'
+import { requiresNodeRuntime, resolveNodeExecutable, type NodeRuntime } from './node-runtime'
+import { pathExists } from './profile'
+import { spawnCommand, withExecutableDirectoryOnPath } from './process'
+
+/** DSH 进程的生命周期：启动、停止、输出转发与状态广播。 */
+
+/** 从进程输出里识别本地服务地址。 */
+export function extractLocalUrl(text: string): string | null {
+  const match = text.match(/https?:\/\/(?:127\.0\.0\.1|localhost)(?::\d+)?(?:\/[^\s]*)?/i)
+  return match?.[0] ?? null
+}
+
+/** 构造 DSH 子进程的环境变量。 */
+export function runtimeEnvironment(settings: AppSettings, base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return { ...base, DSH_HOME: settings.dshHome, FORCE_COLOR: '0' }
+}
+
+const STDERR_CAPTURE_LIMIT = 24_000
+
+export interface RuntimeControllerOptions {
+  readSettings: () => Promise<AppSettings>
+  /** 确保有可用的 Node.js，返回其可执行文件位置。 */
+  prepareNodeRuntime: () => Promise<NodeRuntime>
+  /** 配置的工作目录不存在时的回落目录。 */
+  fallbackWorkspace: () => string
+  emitOutput: (level: RuntimeOutput['level'], text: string) => void
+  emitState: (state: RuntimeState) => void
+  openExternal: (url: string) => void
+}
+
+export interface RuntimeController {
+  state(): RuntimeState
+  isRunning(): boolean
+  start(): Promise<RuntimeState>
+  stop(): Promise<RuntimeState>
+}
+
+export function createRuntimeController(options: RuntimeControllerOptions): RuntimeController {
+  let child: ChildProcessWithoutNullStreams | null = null
+  let startedAt: string | null = null
+  let url: string | null = null
+
+  const state = (): RuntimeState => ({
+    running: child !== null,
+    pid: child?.pid ?? null,
+    startedAt,
+    url,
+  })
+
+  const broadcast = () => options.emitState(state())
+
+  async function start(): Promise<RuntimeState> {
+    if (child) return state()
+
+    const settings = await options.readSettings()
+    const cwd = (await pathExists(settings.workspace)) ? settings.workspace : options.fallbackWorkspace()
+
+    let executable = settings.launchExecutable
+    let environment = runtimeEnvironment(settings, process.env)
+    if (requiresNodeRuntime(executable, settings.launchArgs)) {
+      const nodeRuntime = await options.prepareNodeRuntime()
+      executable = resolveNodeExecutable(executable, nodeRuntime)
+      environment = withExecutableDirectoryOnPath(nodeRuntime.node, environment)
+    }
+
+    options.emitOutput('info', `启动：${executable} ${settings.launchArgs.join(' ')}`)
+    options.emitOutput('info', `工作目录：${cwd}`)
+
+    const started = spawnCommand(executable, settings.launchArgs, { cwd, env: environment })
+    child = started
+    startedAt = new Date().toISOString()
+    url = null
+    broadcast()
+
+    let stderrOutput = ''
+    const handleData = (level: RuntimeOutput['level']) => (chunk: Buffer) => {
+      const text = chunk.toString('utf8')
+      if (level === 'error') stderrOutput = `${stderrOutput}${text}`.slice(-STDERR_CAPTURE_LIMIT)
+      options.emitOutput(level, text)
+      const foundUrl = extractLocalUrl(text)
+      if (foundUrl && foundUrl !== url) {
+        url = foundUrl
+        broadcast()
+        if (settings.openAfterLaunch) options.openExternal(foundUrl)
+      }
+    }
+    started.stdout.on('data', handleData('info'))
+    started.stderr.on('data', handleData('error'))
+
+    started.once('error', error => {
+      options.emitOutput('error', `启动失败：${error.message}`)
+    })
+    started.once('exit', code => {
+      // stop() 会先把 child 置空，据此区分主动停止与意外退出。
+      const expected = child === null
+      child = null
+      if (!expected && code !== 0 && stderrOutput.includes('EADDRINUSE')) {
+        options.emitOutput('error', '本地端口已被其他进程占用。请关闭旧的 DSH 服务，或在启动参数中指定其他端口。')
+      }
+      options.emitOutput(code === 0 || expected ? 'success' : 'error', `DSH 已退出（代码 ${code ?? '未知'}）`)
+      broadcast()
+    })
+
+    return state()
+  }
+
+  async function stop(): Promise<RuntimeState> {
+    const running = child
+    if (!running) return state()
+    child = null
+
+    if (process.platform === 'win32' && running.pid) {
+      // DSH 会派生子进程，必须整棵进程树一起结束。
+      const killer = spawn('taskkill.exe', ['/pid', String(running.pid), '/t', '/f'], { windowsHide: true })
+      await new Promise<void>(resolve => {
+        killer.once('error', () => resolve())
+        killer.once('exit', () => resolve())
+      })
+    } else {
+      running.kill('SIGTERM')
+    }
+
+    options.emitOutput('info', '已发送停止请求。')
+    broadcast()
+    return state()
+  }
+
+  return {
+    state,
+    isRunning: () => child !== null,
+    start,
+    stop,
+  }
+}

--- a/electron/settings.ts
+++ b/electron/settings.ts
@@ -1,0 +1,118 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { DEFAULT_PROFILE_NAME, DSH_PACKAGE_NAME } from '../src/constants'
+import type { AppSettings, DshInstallationStatus } from '../src/types'
+import { isSafeProfileName } from './profile'
+
+/**
+ * 启动器设置的唯一权威来源：默认值、校验、持久化与内存缓存。
+ * 不直接依赖 electron —— 路径与 DSH 检测都由调用方注入，因此可以完整单测。
+ */
+
+export interface DefaultSettingsInput {
+  /** 环境变量 DSH_HOME，缺省时回落到用户主目录下的 .dsh。 */
+  dshHomeFromEnvironment?: string
+  homeDirectory: string
+  documentsDirectory: string
+  /** 系统 npx 的绝对路径；未检测到时使用平台默认名。 */
+  systemNpx?: string
+  platform?: NodeJS.Platform
+}
+
+export function defaultSettings(input: DefaultSettingsInput): AppSettings {
+  const platform = input.platform ?? process.platform
+  return {
+    dshHome: input.dshHomeFromEnvironment || path.join(input.homeDirectory, '.dsh'),
+    profileName: DEFAULT_PROFILE_NAME,
+    workspace: input.documentsDirectory,
+    launchExecutable: input.systemNpx ?? (platform === 'win32' ? 'npx.cmd' : 'npx'),
+    launchArgs: ['--yes', DSH_PACKAGE_NAME, 'web'],
+    openAfterLaunch: true,
+  }
+}
+
+/** 校验并归一化一份来自渲染层的设置。任何一项不合法都直接抛错。 */
+export function validateSettings(input: AppSettings): AppSettings {
+  if (!input || typeof input !== 'object') throw new Error('设置格式无效。')
+  if (!isSafeProfileName(input.profileName)) throw new Error('配置名称只能包含字母、数字、点、横线或下划线。')
+  if (!path.isAbsolute(input.dshHome) || !path.isAbsolute(input.workspace)) throw new Error('目录必须使用完整路径。')
+  if (!input.launchExecutable.trim()) throw new Error('启动命令不能为空。')
+  if (!Array.isArray(input.launchArgs) || input.launchArgs.some(value => typeof value !== 'string')) throw new Error('启动参数格式无效。')
+  return {
+    dshHome: input.dshHome,
+    profileName: input.profileName,
+    workspace: input.workspace,
+    launchExecutable: input.launchExecutable.trim(),
+    launchArgs: input.launchArgs,
+    openAfterLaunch: Boolean(input.openAfterLaunch),
+  }
+}
+
+/** 把磁盘上的设置合并到默认值上，丢弃结构不对的字段。 */
+export function mergeStoredSettings(defaults: AppSettings, stored: Partial<AppSettings> | null): AppSettings {
+  if (!stored || typeof stored !== 'object') return defaults
+  return {
+    ...defaults,
+    ...stored,
+    launchArgs: Array.isArray(stored.launchArgs)
+      ? stored.launchArgs.filter(value => typeof value === 'string')
+      : defaults.launchArgs,
+  }
+}
+
+/**
+ * 判断当前配置是否走「用 npx 临时拉取 DSH」的方式。
+ * 是的话说明还没绑定到某个具体安装，可以在检测到本地 DSH 后自动切换过去。
+ */
+export function usesOnDemandDsh(settings: AppSettings): boolean {
+  const executable = path.basename(settings.launchExecutable).toLowerCase()
+  return (executable === 'npx' || executable === 'npx.cmd') && settings.launchArgs.includes(DSH_PACKAGE_NAME)
+}
+
+/** 已检测到本地 DSH 时，把按需拉取的配置切换为直接调用它。 */
+export function adoptDetectedDsh(settings: AppSettings, detected: DshInstallationStatus): AppSettings {
+  if (!usesOnDemandDsh(settings) || !detected.installed || !detected.executable) return settings
+  return { ...settings, launchExecutable: detected.executable, launchArgs: ['web'] }
+}
+
+export interface SettingsStore {
+  read(): Promise<AppSettings>
+  save(input: AppSettings): Promise<AppSettings>
+}
+
+export interface SettingsStoreOptions {
+  filePath: string
+  createDefaults: () => AppSettings
+  /** 首次读取时用于把按需拉取的配置绑定到已安装的 DSH。 */
+  detectInstalledDsh: (configuredExecutable: string) => Promise<DshInstallationStatus>
+}
+
+export function createSettingsStore(options: SettingsStoreOptions): SettingsStore {
+  let cache: AppSettings | null = null
+
+  return {
+    async read(): Promise<AppSettings> {
+      if (cache) return cache
+      const defaults = options.createDefaults()
+      let stored: Partial<AppSettings> | null = null
+      try {
+        stored = JSON.parse(await readFile(options.filePath, 'utf8')) as Partial<AppSettings>
+      } catch {
+        stored = null
+      }
+      cache = mergeStoredSettings(defaults, stored)
+      if (usesOnDemandDsh(cache)) {
+        cache = adoptDetectedDsh(cache, await options.detectInstalledDsh(cache.launchExecutable))
+      }
+      return cache
+    },
+
+    async save(input: AppSettings): Promise<AppSettings> {
+      const next = validateSettings(input)
+      await mkdir(path.dirname(options.filePath), { recursive: true })
+      await writeFile(options.filePath, `${JSON.stringify(next, null, 2)}\n`, 'utf8')
+      cache = next
+      return next
+    },
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,279 +1,61 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import {
-  ArrowLeft,
-  ArrowDown,
-  ArrowUp,
-  Box,
-  Check,
-  ChevronRight,
-  CircleAlert,
-  CircleCheck,
-  CircleStop,
-  Clock3,
-  Download,
-  Eye,
-  EyeOff,
-  ExternalLink,
-  Folder,
-  Github,
-  GripVertical,
-  KeyRound,
-  Layers3,
-  LoaderCircle,
-  PackageCheck,
-  Play,
-  RefreshCw,
-  Search,
-  Settings,
-  SlidersHorizontal,
-  Sparkles,
-  SquareTerminal,
-  Star,
-  Trash2,
-  X,
-} from 'lucide-react'
-import { demoApi } from './demo-api'
-import packageMetadata from '../package.json'
-import type {
-  AppSettings,
-  CredentialStatus,
-  DshInstallationStatus,
-  InstallProgress,
-  LauncherApi,
-  ManagedPlugin,
-  ProfileState,
-  RepositoryResult,
-  RepositoryInstallResult,
-  RuntimeOutput,
-  RuntimeState,
-  ViewName,
-} from './types'
+import { Layers3, LoaderCircle } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { LauncherApiProvider, resolveLauncherApi, useLauncherApi } from './api/client'
+import { AppHeader } from './components/AppHeader'
+import { LauncherHome } from './components/LauncherHome'
+import { SideNavigation } from './components/SideNavigation'
+import { Toast } from './components/Toast'
+import { ConfirmDialog } from './components/dialogs/ConfirmDialog'
+import { CredentialDialog } from './components/dialogs/CredentialDialog'
+import { SettingsDialog } from './components/dialogs/SettingsDialog'
+import { DSH_REPOSITORY } from './constants'
+import { BUSY } from './hooks/use-async-action'
+import { useLauncherStore } from './hooks/use-launcher-store'
+import { useNavigation } from './hooks/use-navigation'
+import type { ManagedPlugin } from './types'
+import { DiscoverView } from './views/DiscoverView'
+import { PluginsView } from './views/PluginsView'
+import { RuntimeView } from './views/RuntimeView'
 
-const api: LauncherApi = window.launcher ?? demoApi
-
-const EMPTY_RUNTIME: RuntimeState = { running: false, pid: null, startedAt: null, url: null }
-const EMPTY_DSH_INSTALLATION: DshInstallationStatus = { installed: false, version: null, executable: null, source: null }
-const DSH_REPOSITORY = 'deepseek-ai/deepseek-harness'
-
-function formatStars(value: number): string {
-  if (value >= 1000) return `${(value / 1000).toFixed(value >= 10000 ? 1 : 1)}k`
-  return String(value)
-}
-
-function formatDate(value: string): string {
-  const diff = Date.now() - new Date(value).getTime()
-  const minutes = Math.max(1, Math.floor(diff / 60000))
-  if (minutes < 60) return `${minutes} 分钟前`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours} 小时前`
-  const days = Math.floor(hours / 24)
-  if (days < 30) return `${days} 天前`
-  return new Intl.DateTimeFormat('zh-CN', { month: 'short', day: 'numeric' }).format(new Date(value))
-}
-
-function pluginInitial(plugin: ManagedPlugin): string {
-  return plugin.displayName.trim().slice(0, 2).toUpperCase()
-}
-
-function errorText(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
-}
-
-interface ToastState {
-  kind: 'success' | 'error'
-  message: string
-}
-
+/**
+ * 应用根。
+ * 只做三件事：提供主进程 API、组装状态与视图、挂载对话框。
+ * 业务逻辑在 hooks 里，展示逻辑在 components 与 views 里。
+ */
 export default function App() {
-  const [surface, setSurface] = useState<'launcher' | 'manager'>('launcher')
-  const [view, setView] = useState<ViewName>('plugins')
-  const [settings, setSettings] = useState<AppSettings | null>(null)
-  const [profile, setProfile] = useState<ProfileState | null>(null)
-  const [runtime, setRuntime] = useState<RuntimeState>(EMPTY_RUNTIME)
-  const [dshInstallation, setDshInstallation] = useState<DshInstallationStatus>(EMPTY_DSH_INSTALLATION)
-  const [installProgress, setInstallProgress] = useState<InstallProgress | null>(null)
-  const [credentialStatus, setCredentialStatus] = useState<CredentialStatus>({ configured: false })
-  const [logs, setLogs] = useState<RuntimeOutput[]>([])
-  const [selectedPlugin, setSelectedPlugin] = useState<string | null>(null)
+  const api = useMemo(() => resolveLauncherApi(), [])
+  return (
+    <LauncherApiProvider value={api}>
+      <LauncherShell />
+    </LauncherApiProvider>
+  )
+}
+
+function LauncherShell() {
+  const api = useLauncherApi()
+  const store = useLauncherStore()
+  const navigation = useNavigation(message => store.showToast({ kind: 'error', message }))
+
+  // 对话框开关是纯展示状态，不进 store。
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [credentialOpen, setCredentialOpen] = useState(false)
-  const [loading, setLoading] = useState(true)
-  const [busy, setBusy] = useState<string | null>(null)
-  const [toast, setToast] = useState<ToastState | null>(null)
   const [confirmingRemoval, setConfirmingRemoval] = useState<ManagedPlugin | null>(null)
 
-  const showToast = useCallback((next: ToastState) => {
-    setToast(next)
-    window.setTimeout(() => setToast(current => current === next ? null : current), 4200)
-  }, [])
-
-  const refreshProfile = useCallback(async () => {
-    try {
-      const next = await api.readProfile()
-      setProfile(next)
-      setSelectedPlugin(current => current && next.plugins.some(plugin => plugin.packageName === current)
-        ? current
-        : next.plugins[0]?.packageName ?? null)
-    } catch (error) {
-      showToast({ kind: 'error', message: errorText(error) })
-    }
-  }, [showToast])
-
-  useEffect(() => {
-    void Promise.all([api.getSettings(), api.readProfile(), api.getRuntimeState(), api.getDeepSeekCredentialStatus(), api.detectDshInstallation()])
-      .then(([nextSettings, nextProfile, nextRuntime, nextCredentialStatus, nextDshInstallation]) => {
-        setSettings(nextSettings)
-        setProfile(nextProfile)
-        setRuntime(nextRuntime)
-        setCredentialStatus(nextCredentialStatus)
-        setDshInstallation(nextDshInstallation)
-        setSelectedPlugin(nextProfile.plugins[0]?.packageName ?? null)
-      })
-      .catch(error => showToast({ kind: 'error', message: errorText(error) }))
-      .finally(() => setLoading(false))
-    const unsubscribeOutput = api.onRuntimeOutput(output => setLogs(current => [...current.slice(-499), output]))
-    const unsubscribeState = api.onRuntimeState(setRuntime)
-    const unsubscribeInstallProgress = api.onInstallProgress(setInstallProgress)
-    return () => {
-      unsubscribeOutput()
-      unsubscribeState()
-      unsubscribeInstallProgress()
-    }
-  }, [showToast])
-
-  const selected = profile?.plugins.find(plugin => plugin.packageName === selectedPlugin) ?? null
-
-  const showManager = () => {
-    setSurface('manager')
-    void api.setWindowMode('manager').catch(error => showToast({ kind: 'error', message: errorText(error) }))
-  }
-
-  const showLauncher = () => {
-    setSurface('launcher')
-    void api.setWindowMode('launcher').catch(error => showToast({ kind: 'error', message: errorText(error) }))
-  }
+  const installingDsh = store.busy === BUSY.dshInstall
+  const runtimeBusy = store.busy === BUSY.runtime || installingDsh
 
   const toggleRuntime = async () => {
-    const needsInstallation = !runtime.running && !dshInstallation.installed
-    setBusy(needsInstallation ? 'dsh-install' : 'runtime')
-    try {
-      if (needsInstallation) {
-        setInstallProgress({ repository: DSH_REPOSITORY, kind: 'dsh', phase: 'preparing', percent: 0, message: '正在准备本地 DSH' })
-        const result = await api.installPlugin(DSH_REPOSITORY)
-        setSettings(result.settings)
-        setProfile(result.profile)
-        setDshInstallation(result.dshInstallation)
-        setSelectedPlugin(result.profile.plugins[0]?.packageName ?? null)
-        showToast({ kind: 'success', message: `本地 DSH ${result.dshInstallation.version ?? ''} 已安装，可以启动。` })
-        return
-      }
-      const next = runtime.running ? await api.stopRuntime() : await api.startRuntime()
-      setRuntime(next)
-      if (!runtime.running) setView('runtime')
-    } catch (error) {
-      showToast({ kind: 'error', message: errorText(error) })
-    } finally {
-      setBusy(null)
-    }
+    // 刚启动时自动切到日志视图，让用户看到启动过程。
+    if (await store.toggleRuntime() === 'started') navigation.setView('runtime')
   }
 
-  const saveSettings = async (next: AppSettings) => {
-    setBusy('settings')
-    try {
-      const saved = await api.saveSettings(next)
-      setSettings(saved)
-      setDshInstallation(await api.detectDshInstallation())
-      setCredentialStatus(await api.getDeepSeekCredentialStatus())
-      setSettingsOpen(false)
-      await refreshProfile()
-      showToast({ kind: 'success', message: '设置已保存。' })
-    } catch (error) {
-      showToast({ kind: 'error', message: errorText(error) })
-    } finally {
-      setBusy(null)
-    }
+  const openHarness = () => {
+    if (store.runtime.url) void api.openExternal(store.runtime.url)
   }
 
-  const saveApiKey = async (apiKey: string) => {
-    setBusy('credential')
-    try {
-      setCredentialStatus(await api.setDeepSeekApiKey(apiKey))
-      setCredentialOpen(false)
-      showToast({ kind: 'success', message: 'DeepSeek API Key 已保存，DSH 可立即使用。' })
-    } catch (error) {
-      showToast({ kind: 'error', message: errorText(error) })
-    } finally {
-      setBusy(null)
-    }
-  }
+  const closeWindow = () => void api.closeWindow()
 
-  const clearApiKey = async () => {
-    setBusy('credential')
-    try {
-      setCredentialStatus(await api.clearDeepSeekApiKey())
-      setCredentialOpen(false)
-      showToast({ kind: 'success', message: 'DeepSeek API Key 已清除。' })
-    } catch (error) {
-      showToast({ kind: 'error', message: errorText(error) })
-    } finally {
-      setBusy(null)
-    }
-  }
-
-  const togglePlugin = async (plugin: ManagedPlugin, enabled: boolean) => {
-    setBusy(plugin.packageName)
-    try {
-      const next = await api.togglePlugin(plugin.packageName, enabled)
-      setProfile(next)
-      showToast({ kind: 'success', message: enabled ? '插件将在下次启动时加载。' : '插件已停用，但仍保留在本机。' })
-    } catch (error) {
-      showToast({ kind: 'error', message: errorText(error) })
-    } finally {
-      setBusy(null)
-    }
-  }
-
-  const reorder = async (packageNames: string[]) => {
-    if (!profile) return
-    const previous = profile
-    const orderMap = new Map(packageNames.map((name, index) => [name, index + 1]))
-    setProfile({
-      ...profile,
-      activeBundles: packageNames,
-      plugins: [...profile.plugins].sort((a, b) => {
-        if (a.enabled !== b.enabled) return a.enabled ? -1 : 1
-        return (orderMap.get(a.packageName) ?? 999) - (orderMap.get(b.packageName) ?? 999)
-      }).map(plugin => ({ ...plugin, order: orderMap.get(plugin.packageName) ?? null })),
-    })
-    setBusy('reorder')
-    try {
-      setProfile(await api.reorderPlugins(packageNames))
-    } catch (error) {
-      setProfile(previous)
-      showToast({ kind: 'error', message: errorText(error) })
-    } finally {
-      setBusy(null)
-    }
-  }
-
-  const uninstall = async () => {
-    const plugin = confirmingRemoval
-    if (!plugin) return
-    setConfirmingRemoval(null)
-    setBusy(plugin.packageName)
-    try {
-      const next = await api.uninstallPlugin(plugin.packageName)
-      setProfile(next)
-      setSelectedPlugin(next.plugins[0]?.packageName ?? null)
-      showToast({ kind: 'success', message: `${plugin.displayName} 已卸载。` })
-    } catch (error) {
-      showToast({ kind: 'error', message: errorText(error) })
-    } finally {
-      setBusy(null)
-    }
-  }
-
-  if (loading || !settings || !profile) {
+  if (store.loading || !store.settings || !store.profile) {
     return (
       <div className="app-loading">
         <div className="brand-mark"><Layers3 size={22} /></div>
@@ -283,87 +65,89 @@ export default function App() {
     )
   }
 
+  const { settings, profile } = store
+
   return (
     <>
-      {surface === 'launcher' ? (
+      {navigation.surface === 'launcher' ? (
         <LauncherHome
           settings={settings}
           profile={profile}
-          runtime={runtime}
-          dshInstallation={dshInstallation}
-          installProgress={installProgress?.repository === DSH_REPOSITORY ? installProgress : null}
-          busy={busy === 'runtime' || busy === 'dsh-install'}
-          installingDsh={busy === 'dsh-install'}
+          runtime={store.runtime}
+          dshInstallation={store.dshInstallation}
+          installProgress={store.installProgress?.repository === DSH_REPOSITORY ? store.installProgress : null}
+          busy={runtimeBusy}
+          installingDsh={installingDsh}
           onCredential={() => setCredentialOpen(true)}
-          onManage={showManager}
+          onManage={navigation.showManager}
           onToggleRuntime={toggleRuntime}
-          onOpenHarness={() => runtime.url && void api.openExternal(runtime.url)}
-          onClose={() => void api.closeWindow()}
+          onOpenHarness={openHarness}
+          onClose={closeWindow}
         />
       ) : (
         <div className="app-shell">
           <AppHeader
-            runtime={runtime}
-            busy={busy === 'runtime' || busy === 'dsh-install'}
-            dshInstalled={dshInstallation.installed}
-            installingDsh={busy === 'dsh-install'}
+            runtime={store.runtime}
+            busy={runtimeBusy}
+            dshInstalled={store.dshInstallation.installed}
+            installingDsh={installingDsh}
             profileName={settings.profileName}
-            credentialStatus={credentialStatus}
-            onBack={showLauncher}
+            credentialStatus={store.credentialStatus}
+            onBack={navigation.showLauncher}
             onCredential={() => setCredentialOpen(true)}
             onSettings={() => setSettingsOpen(true)}
             onToggleRuntime={toggleRuntime}
-            onClose={() => void api.closeWindow()}
+            onClose={closeWindow}
           />
           <div className="app-body">
             <SideNavigation
-              view={view}
+              view={navigation.view}
               profile={profile}
-              runtime={runtime}
+              runtime={store.runtime}
               profileName={settings.profileName}
-              onChange={setView}
+              onChange={navigation.setView}
             />
             <main className="workspace">
-              {view === 'plugins' && (
+              {navigation.view === 'plugins' && (
                 <PluginsView
                   profile={profile}
-                  selected={selected}
-                  busy={busy}
-                  onSelect={plugin => setSelectedPlugin(plugin.packageName)}
-                  onToggle={togglePlugin}
-                  onReorder={reorder}
-                  onRefresh={refreshProfile}
-                  onBrowse={() => setView('discover')}
+                  selected={store.selected}
+                  busy={store.busy}
+                  onSelect={plugin => store.selectPlugin(plugin.packageName)}
+                  onToggle={store.togglePlugin}
+                  onReorder={store.reorderPlugins}
+                  onRefresh={store.refreshProfile}
+                  onBrowse={() => navigation.setView('discover')}
                   onOpenPath={path => void api.openPath(path)}
                   onOpenRepository={url => void api.openExternal(url)}
                   onUninstall={setConfirmingRemoval}
                 />
               )}
-              {view === 'discover' && (
+              {navigation.view === 'discover' && (
                 <DiscoverView
                   profile={profile}
                   onInstalled={result => {
-                    setProfile(result.profile)
-                    setSettings(result.settings)
-                    setDshInstallation(result.dshInstallation)
-                    showToast({
+                    store.applyInstallResult(result)
+                    store.showToast({
                       kind: 'success',
-                      message: result.kind === 'dsh' ? `本地 DSH ${result.dshInstallation.version ?? ''} 已安装。` : '插件已安装并加入加载顺序。',
+                      message: result.kind === 'dsh'
+                        ? `本地 DSH ${result.dshInstallation.version ?? ''} 已安装。`
+                        : '插件已安装并加入加载顺序。',
                     })
                   }}
-                  onError={message => showToast({ kind: 'error', message })}
+                  onError={message => store.showToast({ kind: 'error', message })}
                   onOpenRepository={url => void api.openExternal(url)}
                 />
               )}
-              {view === 'runtime' && (
+              {navigation.view === 'runtime' && (
                 <RuntimeView
-                  runtime={runtime}
+                  runtime={store.runtime}
                   settings={settings}
-                  logs={logs}
-                  busy={busy === 'runtime' || busy === 'dsh-install'}
+                  logs={store.logs}
+                  busy={runtimeBusy}
                   onToggleRuntime={toggleRuntime}
-                  onOpenHarness={() => runtime.url && void api.openExternal(runtime.url)}
-                  onClearLogs={() => setLogs([])}
+                  onOpenHarness={openHarness}
+                  onClearLogs={store.clearLogs}
                   onOpenSettings={() => setSettingsOpen(true)}
                 />
               )}
@@ -371,769 +155,36 @@ export default function App() {
           </div>
         </div>
       )}
+
       {settingsOpen && (
         <SettingsDialog
           settings={settings}
-          busy={busy === 'settings'}
+          busy={store.busy === BUSY.settings}
           onClose={() => setSettingsOpen(false)}
-          onSave={saveSettings}
+          onSave={async next => { if (await store.saveSettings(next)) setSettingsOpen(false) }}
         />
       )}
       {credentialOpen && (
         <CredentialDialog
-          status={credentialStatus}
-          busy={busy === 'credential'}
+          status={store.credentialStatus}
+          busy={store.busy === BUSY.credential}
           onClose={() => setCredentialOpen(false)}
-          onSave={saveApiKey}
-          onClear={clearApiKey}
+          onSave={async apiKey => { if (await store.saveApiKey(apiKey)) setCredentialOpen(false) }}
+          onClear={async () => { if (await store.clearApiKey()) setCredentialOpen(false) }}
         />
       )}
       {confirmingRemoval && (
         <ConfirmDialog
           plugin={confirmingRemoval}
           onCancel={() => setConfirmingRemoval(null)}
-          onConfirm={uninstall}
+          onConfirm={() => {
+            const plugin = confirmingRemoval
+            setConfirmingRemoval(null)
+            void store.uninstallPlugin(plugin)
+          }}
         />
       )}
-      {toast && <Toast toast={toast} onClose={() => setToast(null)} />}
+      {store.toast && <Toast toast={store.toast} onClose={store.dismissToast} />}
     </>
-  )
-}
-
-function LauncherHome({ settings, profile, runtime, dshInstallation, installProgress, busy, installingDsh, onCredential, onManage, onToggleRuntime, onOpenHarness, onClose }: {
-  settings: AppSettings
-  profile: ProfileState
-  runtime: RuntimeState
-  dshInstallation: DshInstallationStatus
-  installProgress: InstallProgress | null
-  busy: boolean
-  installingDsh: boolean
-  onCredential: () => void
-  onManage: () => void
-  onToggleRuntime: () => void
-  onOpenHarness: () => void
-  onClose: () => void
-}) {
-  const needsInstallation = !dshInstallation.installed
-  const runtimeLabel = busy
-    ? installingDsh ? '正在安装' : runtime.running ? '正在停止' : '正在启动'
-    : runtime.running ? runtime.url ? '已就绪' : '正在启动'
-      : needsInstallation ? '尚未安装' : '等待启动'
-
-  return (
-    <div className="launcher-home">
-      <div className="launcher-drag-region" aria-hidden="true" />
-      <button className="launcher-window-close" type="button" title="关闭" aria-label="关闭" onClick={onClose}>
-        <X size={18} />
-      </button>
-
-      <main className="launcher-stage">
-        <div className="launcher-title-block">
-          <span className="launcher-kicker">LOCAL AI WORKSPACE</span>
-          <h1>DeepSeek Harness</h1>
-          <p>{needsInstallation ? '首次部署准备' : `本地 DSH ${dshInstallation.version ?? ''}`} · {profile.activeBundles.length} 个加载层</p>
-        </div>
-
-        <div className="launcher-controls">
-          <div className="launcher-runtime-state">
-            <span className={`launcher-state-dot ${runtime.running ? 'running' : ''}`} />
-            <div><small>运行状态</small><strong>{runtimeLabel}</strong></div>
-            <span>{runtime.running && runtime.pid ? `PID ${runtime.pid}` : settings.profileName}</span>
-          </div>
-
-          <div className="launcher-action-grid">
-            <button
-              type="button"
-              className={`launcher-start-button ${runtime.running ? 'stop' : ''}`}
-              onClick={onToggleRuntime}
-              disabled={busy}
-            >
-              {busy ? <LoaderCircle className="spin" size={24} /> : runtime.running ? <CircleStop size={24} /> : needsInstallation ? <Download size={24} /> : <Play size={25} fill="currentColor" />}
-              <span>
-                <small>{installingDsh ? installProgress?.message ?? '正在准备本地 DSH' : runtime.running ? '结束本地服务' : needsInstallation ? '首次使用需要完成本地部署' : '启动本地工作台'}</small>
-                <strong>{runtime.running ? '停止 DSH' : installingDsh ? installProgress?.indeterminate ? '安装进行中' : `安装 DSH ${installProgress?.percent ?? 0}%` : needsInstallation ? '下载安装 DSH' : '启动 DSH'}</strong>
-              </span>
-            </button>
-            <button type="button" className="launcher-utility-button" onClick={onManage} disabled={busy}><Settings size={17} /><span>管理</span></button>
-            <button type="button" className="launcher-utility-button" onClick={onCredential} disabled={busy}><KeyRound size={17} /><span>API Key</span></button>
-          </div>
-
-          <div className="launcher-profile-row">
-            <span>启动配置</span>
-            <label className="launcher-profile-select">
-              <Box size={15} />
-              <select aria-label="启动配置" value={settings.profileName} onChange={() => undefined}>
-                <option value={settings.profileName}>{settings.profileName}</option>
-              </select>
-            </label>
-            {runtime.url ? (
-              <button type="button" className="launcher-open-button" onClick={onOpenHarness}>打开 Harness<ExternalLink size={13} /></button>
-            ) : (
-              <span className="launcher-runtime-source">{needsInstallation ? '等待部署' : dshInstallation.source === 'system' ? '系统安装' : '启动器安装'}</span>
-            )}
-          </div>
-        </div>
-      </main>
-
-      <footer className="launcher-footer">
-        <span>DSH Launcher {packageMetadata.version}</span>
-        <span>{profile.initialized ? `${profile.plugins.length} 个插件` : 'Profile 等待初始化'}</span>
-      </footer>
-    </div>
-  )
-}
-
-function AppHeader({ runtime, busy, dshInstalled, installingDsh, profileName, credentialStatus, onBack, onCredential, onSettings, onToggleRuntime, onClose }: {
-  runtime: RuntimeState
-  busy: boolean
-  dshInstalled: boolean
-  installingDsh: boolean
-  profileName: string
-  credentialStatus: CredentialStatus
-  onBack: () => void
-  onCredential: () => void
-  onSettings: () => void
-  onToggleRuntime: () => void
-  onClose: () => void
-}) {
-  return (
-    <header className="app-header">
-      <div className="brand-block">
-        <button className="icon-button manager-back" type="button" title="返回启动页" aria-label="返回启动页" onClick={onBack}>
-          <ArrowLeft size={18} />
-        </button>
-        <div className="brand-mark"><Layers3 size={21} strokeWidth={2.2} /></div>
-        <div>
-          <div className="brand-name">DSH Launcher</div>
-          <div className="brand-subtitle">DeepSeek Harness 管理器</div>
-        </div>
-      </div>
-      <div className="header-context">
-        <span className="context-label">配置</span>
-        <strong>{profileName}</strong>
-        <ChevronRight size={14} />
-        <span className={`status-dot ${runtime.running ? 'running' : ''}`} />
-        <span>{runtime.running ? `运行中 · PID ${runtime.pid}` : dshInstalled ? '尚未启动' : '尚未安装'}</span>
-      </div>
-      <div className="header-actions">
-        <button
-          className={`credential-button ${credentialStatus.configured ? 'configured' : ''}`}
-          type="button"
-          title="配置 DeepSeek API Key"
-          onClick={onCredential}
-        >
-          <KeyRound size={17} />
-          <span>DeepSeek Key</span>
-          <span className="credential-state">{credentialStatus.configured ? '已配置' : '未配置'}</span>
-        </button>
-        <button className="icon-button" type="button" title="启动器设置" aria-label="启动器设置" onClick={onSettings}>
-          <Settings size={19} />
-        </button>
-        <button className={`primary-command ${runtime.running ? 'stop' : ''}`} type="button" onClick={onToggleRuntime} disabled={busy}>
-          {busy ? <LoaderCircle className="spin" size={18} /> : runtime.running ? <CircleStop size={18} /> : dshInstalled ? <Play size={18} fill="currentColor" /> : <Download size={18} />}
-          <span>{runtime.running ? '停止 DSH' : installingDsh ? '安装中' : dshInstalled ? '启动 DSH' : '安装 DSH'}</span>
-        </button>
-        <button className="manager-window-close" type="button" title="关闭" aria-label="关闭" onClick={onClose}>
-          <X size={18} />
-        </button>
-      </div>
-    </header>
-  )
-}
-
-function SideNavigation({ view, profile, runtime, profileName, onChange }: {
-  view: ViewName
-  profile: ProfileState
-  runtime: RuntimeState
-  profileName: string
-  onChange: (view: ViewName) => void
-}) {
-  const entries: Array<{ id: ViewName; label: string; icon: typeof Box; count?: number }> = [
-    { id: 'plugins', label: '插件顺序', icon: Layers3, count: profile.plugins.length },
-    { id: 'discover', label: '发现插件', icon: Sparkles },
-    { id: 'runtime', label: '运行与日志', icon: SquareTerminal },
-  ]
-  return (
-    <aside className="side-navigation">
-      <nav aria-label="主导航">
-        {entries.map(entry => {
-          const Icon = entry.icon
-          return (
-            <button
-              key={entry.id}
-              type="button"
-              className={view === entry.id ? 'active' : ''}
-              aria-label={entry.label}
-              title={entry.label}
-              onClick={() => onChange(entry.id)}
-            >
-              <Icon size={18} />
-              <span>{entry.label}</span>
-              {entry.count !== undefined && <span className="nav-count">{entry.count}</span>}
-            </button>
-          )
-        })}
-      </nav>
-      <div className="profile-summary">
-        <div className="profile-icon"><Box size={17} /></div>
-        <div className="profile-copy">
-          <strong>{profileName}</strong>
-          <span>{profile.initialized ? `${profile.activeBundles.length} 层已激活` : '等待初始化'}</span>
-        </div>
-        <span className={`mini-status ${runtime.running ? 'running' : ''}`} title={runtime.running ? 'DSH 正在运行' : 'DSH 未运行'} />
-      </div>
-    </aside>
-  )
-}
-
-function PluginsView({ profile, selected, busy, onSelect, onToggle, onReorder, onRefresh, onBrowse, onOpenPath, onOpenRepository, onUninstall }: {
-  profile: ProfileState
-  selected: ManagedPlugin | null
-  busy: string | null
-  onSelect: (plugin: ManagedPlugin) => void
-  onToggle: (plugin: ManagedPlugin, enabled: boolean) => void
-  onReorder: (names: string[]) => void
-  onRefresh: () => void
-  onBrowse: () => void
-  onOpenPath: (path: string) => void
-  onOpenRepository: (url: string) => void
-  onUninstall: (plugin: ManagedPlugin) => void
-}) {
-  const [filter, setFilter] = useState('')
-  const [dragged, setDragged] = useState<string | null>(null)
-  const active = profile.plugins.filter(plugin => plugin.enabled)
-  const inactive = profile.plugins.filter(plugin => !plugin.enabled)
-  const visible = (plugin: ManagedPlugin) => !filter || `${plugin.displayName} ${plugin.packageName}`.toLowerCase().includes(filter.toLowerCase())
-
-  const move = (packageName: string, direction: -1 | 1) => {
-    const names = active.map(plugin => plugin.packageName)
-    const index = names.indexOf(packageName)
-    const target = index + direction
-    if (index < 0 || target < 0 || target >= names.length) return
-    ;[names[index], names[target]] = [names[target], names[index]]
-    onReorder(names)
-  }
-
-  const dropAt = (targetName: string) => {
-    if (!dragged || dragged === targetName) return setDragged(null)
-    const names = active.map(plugin => plugin.packageName)
-    const from = names.indexOf(dragged)
-    const to = names.indexOf(targetName)
-    if (from < 0 || to < 0) return setDragged(null)
-    names.splice(to, 0, names.splice(from, 1)[0])
-    setDragged(null)
-    onReorder(names)
-  }
-
-  return (
-    <div className="page plugins-page">
-      <PageHeading
-        eyebrow="WEB PROFILE"
-        title="插件加载顺序"
-        description="上方先加载，下方可覆盖前序配置。停用插件不会从本机删除。"
-        actions={(
-          <>
-            <button className="secondary-button" type="button" onClick={onRefresh}><RefreshCw size={17} />刷新</button>
-            <button className="secondary-button accent" type="button" onClick={onBrowse}><Download size={17} />获取插件</button>
-          </>
-        )}
-      />
-
-      <div className="stats-strip" aria-label="配置概况">
-        <div><strong>{profile.activeBundles.length}</strong><span>已激活</span></div>
-        <div><strong>{profile.disabledCount}</strong><span>已停用</span></div>
-        <div><strong>{profile.dependencyCount}</strong><span>第三方依赖</span></div>
-        <button type="button" onClick={() => onOpenPath(profile.profileDir)} title="在资源管理器中打开配置目录">
-          <Folder size={16} /><span className="path-clip">{profile.profileDir}</span><ExternalLink size={14} />
-        </button>
-      </div>
-
-      {!profile.initialized ? (
-        <EmptyProfile onBrowse={onBrowse} />
-      ) : (
-        <div className="plugin-layout">
-          <section className="plugin-list-panel" aria-label="插件列表">
-            <div className="list-toolbar">
-              <label className="search-field compact">
-                <Search size={16} />
-                <input value={filter} onChange={event => setFilter(event.target.value)} placeholder="筛选已安装插件" />
-                {filter && <button type="button" onClick={() => setFilter('')} aria-label="清除筛选"><X size={15} /></button>}
-              </label>
-              <span>{active.length} 个加载层</span>
-            </div>
-            <div className="column-headings" aria-hidden="true">
-              <span>优先级</span><span>插件</span><span>版本</span><span>状态</span><span />
-            </div>
-            <div className="plugin-rows">
-              {active.filter(visible).map((plugin, index) => (
-                <PluginRow
-                  key={plugin.packageName}
-                  plugin={plugin}
-                  selected={selected?.packageName === plugin.packageName}
-                  busy={busy === plugin.packageName}
-                  dragging={dragged === plugin.packageName}
-                  canMoveUp={index > 0}
-                  canMoveDown={index < active.length - 1}
-                  onSelect={() => onSelect(plugin)}
-                  onToggle={enabled => onToggle(plugin, enabled)}
-                  onMove={moveDirection => move(plugin.packageName, moveDirection)}
-                  onDragStart={() => setDragged(plugin.packageName)}
-                  onDrop={() => dropAt(plugin.packageName)}
-                />
-              ))}
-              {inactive.length > 0 && <div className="disabled-divider"><span>已停用</span><i /></div>}
-              {inactive.filter(visible).map(plugin => (
-                <PluginRow
-                  key={plugin.packageName}
-                  plugin={plugin}
-                  selected={selected?.packageName === plugin.packageName}
-                  busy={busy === plugin.packageName}
-                  dragging={false}
-                  canMoveUp={false}
-                  canMoveDown={false}
-                  onSelect={() => onSelect(plugin)}
-                  onToggle={enabled => onToggle(plugin, enabled)}
-                  onMove={() => undefined}
-                  onDragStart={() => undefined}
-                  onDrop={() => undefined}
-                />
-              ))}
-            </div>
-          </section>
-          <PluginDetails
-            plugin={selected}
-            onOpenRepository={onOpenRepository}
-            onUninstall={onUninstall}
-          />
-        </div>
-      )}
-    </div>
-  )
-}
-
-function PluginRow({ plugin, selected, busy, dragging, canMoveUp, canMoveDown, onSelect, onToggle, onMove, onDragStart, onDrop }: {
-  plugin: ManagedPlugin
-  selected: boolean
-  busy: boolean
-  dragging: boolean
-  canMoveUp: boolean
-  canMoveDown: boolean
-  onSelect: () => void
-  onToggle: (enabled: boolean) => void
-  onMove: (direction: -1 | 1) => void
-  onDragStart: () => void
-  onDrop: () => void
-}) {
-  return (
-    <div
-      className={`plugin-row ${selected ? 'selected' : ''} ${plugin.enabled ? '' : 'disabled'} ${dragging ? 'dragging' : ''}`}
-      draggable={plugin.enabled}
-      onDragStart={event => {
-        event.dataTransfer.effectAllowed = 'move'
-        onDragStart()
-      }}
-      onDragOver={event => event.preventDefault()}
-      onDrop={event => { event.preventDefault(); onDrop() }}
-      onClick={onSelect}
-    >
-      <div className="priority-cell">
-        {plugin.enabled ? <><GripVertical size={15} /><strong>{String(plugin.order).padStart(2, '0')}</strong></> : <span>—</span>}
-      </div>
-      <div className="plugin-identity">
-        <div className={`plugin-glyph glyph-${plugin.packageName.length % 4}`}>{pluginInitial(plugin)}</div>
-        <div><strong>{plugin.displayName}</strong><span>{plugin.packageName}</span></div>
-      </div>
-      <span className="plugin-version">{plugin.version}</span>
-      <div className="state-cell">
-        {!plugin.compatible && <span className="compatibility-warning" title="未检测到 dsh.bundle 声明"><CircleAlert size={16} /></span>}
-        <label className={`switch ${plugin.locked ? 'locked' : ''}`} title={plugin.locked ? '核心组合层始终启用' : plugin.enabled ? '停用插件' : '启用插件'} onClick={event => event.stopPropagation()}>
-          <input
-            type="checkbox"
-            checked={plugin.enabled}
-            disabled={plugin.locked || busy || !plugin.compatible}
-            onChange={event => onToggle(event.target.checked)}
-            aria-label={`${plugin.enabled ? '停用' : '启用'} ${plugin.displayName}`}
-          />
-          <span>{busy && <LoaderCircle className="spin" size={11} />}</span>
-        </label>
-      </div>
-      <div className="row-actions" onClick={event => event.stopPropagation()}>
-        <button type="button" disabled={!canMoveUp} onClick={() => onMove(-1)} title="向上移动" aria-label={`向上移动 ${plugin.displayName}`}><ArrowUp size={15} /></button>
-        <button type="button" disabled={!canMoveDown} onClick={() => onMove(1)} title="向下移动" aria-label={`向下移动 ${plugin.displayName}`}><ArrowDown size={15} /></button>
-      </div>
-    </div>
-  )
-}
-
-function PluginDetails({ plugin, onOpenRepository, onUninstall }: {
-  plugin: ManagedPlugin | null
-  onOpenRepository: (url: string) => void
-  onUninstall: (plugin: ManagedPlugin) => void
-}) {
-  if (!plugin) return <aside className="plugin-details empty">选择一个插件查看详情</aside>
-  return (
-    <aside className="plugin-details">
-      <div className="detail-topline">
-        <div className={`plugin-glyph large glyph-${plugin.packageName.length % 4}`}>{pluginInitial(plugin)}</div>
-        <div className={`detail-state ${plugin.enabled ? 'active' : ''}`}><span />{plugin.enabled ? '已激活' : '已停用'}</div>
-      </div>
-      <h2>{plugin.displayName}</h2>
-      <p className="package-name">{plugin.packageName}</p>
-      <p className="plugin-description">{plugin.description}</p>
-      <dl>
-        <div><dt>加载优先级</dt><dd>{plugin.order ? `#${String(plugin.order).padStart(2, '0')}` : '不加载'}</dd></div>
-        <div><dt>版本</dt><dd>{plugin.version}</dd></div>
-        <div><dt>来源</dt><dd>{plugin.builtin ? 'DSH 内置' : 'Profile 依赖'}</dd></div>
-        <div><dt>兼容性</dt><dd className={plugin.compatible ? 'good' : 'warning'}>{plugin.compatible ? 'Bundle 已识别' : '未检测到 Bundle'}</dd></div>
-      </dl>
-      <div className="detail-note">
-        <SlidersHorizontal size={16} />
-        <p>{plugin.enabled ? '本层会按当前优先级参与下一次 DSH 启动。' : '插件文件仍保留在本机，可随时重新启用。'}</p>
-      </div>
-      <div className="detail-actions">
-        {plugin.repository && <button type="button" className="secondary-button full" onClick={() => onOpenRepository(plugin.repository!)}><Github size={16} />查看仓库<ExternalLink size={14} /></button>}
-        {!plugin.builtin && <button type="button" className="danger-button full" onClick={() => onUninstall(plugin)}><Trash2 size={16} />从此配置卸载</button>}
-      </div>
-    </aside>
-  )
-}
-
-function EmptyProfile({ onBrowse }: { onBrowse: () => void }) {
-  return (
-    <div className="empty-state">
-      <div className="empty-icon"><PackageCheck size={28} /></div>
-      <h2>Web 配置尚未初始化</h2>
-      <p>首次启动 DSH 或安装插件时，官方 CLI 会创建 profile。启动器随后会在这里显示真实的组合层。</p>
-      <button type="button" className="primary-command" onClick={onBrowse}><Sparkles size={17} />浏览插件</button>
-    </div>
-  )
-}
-
-function DiscoverView({ profile, onInstalled, onError, onOpenRepository }: {
-  profile: ProfileState
-  onInstalled: (result: RepositoryInstallResult) => void
-  onError: (message: string) => void
-  onOpenRepository: (url: string) => void
-}) {
-  const [query, setQuery] = useState('')
-  const [sort, setSort] = useState<'stars' | 'updated'>('stars')
-  const [repositories, setRepositories] = useState<RepositoryResult[]>([])
-  const [total, setTotal] = useState(0)
-  const [loading, setLoading] = useState(true)
-  const [installing, setInstalling] = useState<string | null>(null)
-  const [installProgress, setInstallProgress] = useState<InstallProgress | null>(null)
-  const [dshInstallation, setDshInstallation] = useState<DshInstallationStatus>({ installed: false, version: null, executable: null, source: null })
-
-  const search = useCallback(async (searchQuery = query, searchSort = sort) => {
-    setLoading(true)
-    try {
-      const result = await api.discoverPlugins(searchQuery, searchSort)
-      setRepositories(result.repositories)
-      setTotal(result.totalCount)
-      setDshInstallation(result.dshInstallation)
-    } catch (error) {
-      onError(errorText(error))
-    } finally {
-      setLoading(false)
-    }
-  }, [onError, query, sort])
-
-  useEffect(() => { void search('', 'stars') }, [])
-  useEffect(() => api.onInstallProgress(setInstallProgress), [])
-
-  const installedRepos = useMemo(() => new Set(profile.plugins.map(plugin => plugin.repositoryFullName?.toLowerCase()).filter(Boolean)), [profile.plugins])
-
-  const install = async (repo: RepositoryResult) => {
-    setInstalling(repo.fullName)
-    setInstallProgress({ repository: repo.fullName, kind: repo.kind, phase: 'preparing', percent: 0, message: repo.kind === 'dsh' ? '正在准备本地 DSH' : '正在准备安装插件' })
-    try {
-      const result = await api.installPlugin(repo.fullName)
-      setDshInstallation(result.dshInstallation)
-      onInstalled(result)
-    } catch (error) {
-      onError(errorText(error))
-    } finally {
-      setInstalling(null)
-    }
-  }
-
-  return (
-    <div className="page discover-page">
-      <PageHeading eyebrow="GITHUB CATALOG" title="发现 DSH 插件" description={`从 GitHub dsh-plugin 主题中浏览 ${total ? total.toLocaleString('zh-CN') : ''} 个公开仓库。安装前请检查仓库说明与来源。`} />
-      <div className="discovery-controls">
-        <form className="search-field large" onSubmit={event => { event.preventDefault(); void search() }}>
-          <Search size={18} />
-          <input value={query} onChange={event => setQuery(event.target.value)} placeholder="搜索名称、作者或说明" aria-label="搜索插件" />
-          {query && <button type="button" onClick={() => { setQuery(''); void search('', sort) }} aria-label="清除搜索"><X size={16} /></button>}
-          <button type="submit" className="search-submit">搜索</button>
-        </form>
-        <div className="segmented-control" aria-label="插件排序方式">
-          <button type="button" className={sort === 'stars' ? 'active' : ''} onClick={() => { setSort('stars'); void search(query, 'stars') }}><Star size={15} />热门</button>
-          <button type="button" className={sort === 'updated' ? 'active' : ''} onClick={() => { setSort('updated'); void search(query, 'updated') }}><Clock3 size={15} />最近更新</button>
-        </div>
-      </div>
-
-      <div className="catalog-note"><CircleAlert size={16} /><span>GitHub 主题表示仓库自我声明为 DSH 插件；官方 <code>deepseek-ai/deepseek-harness</code> 会作为 DSH 本体安装到启动器的本地运行目录。</span></div>
-      <section className="repository-list" aria-busy={loading}>
-        <div className="repository-headings" aria-hidden="true"><span>仓库</span><span>语言</span><span>活跃度</span><span /></div>
-        {loading ? (
-          <div className="list-loading"><LoaderCircle className="spin" size={21} />正在读取 GitHub 目录</div>
-        ) : repositories.length === 0 ? (
-          <div className="list-loading"><Search size={21} />没有找到匹配的仓库</div>
-        ) : repositories.map(repo => {
-          const installed = repo.kind === 'dsh' ? dshInstallation.installed : installedRepos.has(repo.fullName.toLowerCase())
-          const progress = installing === repo.fullName && installProgress?.repository === repo.fullName ? installProgress : null
-          const indeterminate = progress?.indeterminate === true && progress.phase !== 'error'
-          return (
-            <article className={`repository-row ${repo.kind === 'dsh' ? 'dsh-core-row' : ''}`} key={repo.id}>
-              <div className="repo-main">
-                <div className={`repo-icon ${repo.kind === 'dsh' ? 'dsh-core-icon' : ''}`}>{repo.kind === 'dsh' ? <Layers3 size={18} /> : <Github size={18} />}</div>
-                <div>
-                  <div className="repo-title-line">
-                    <button type="button" className="repo-title" onClick={() => onOpenRepository(repo.url)}><span>{repo.owner}/</span><strong>{repo.name}</strong><ExternalLink size={13} /></button>
-                    {repo.kind === 'dsh' && <span className="dsh-core-badge">DSH 本体</span>}
-                  </div>
-                  <p>{repo.description}</p>
-                  <div className="topic-list">{repo.topics.slice(0, 3).map(topic => <span key={topic}>{topic}</span>)}</div>
-                </div>
-              </div>
-              <div className="language-cell"><i className={`language-dot lang-${(repo.language ?? 'other').toLowerCase()}`} />{repo.language ?? '其他'}</div>
-              <div className="activity-cell"><span><Star size={15} fill="currentColor" />{formatStars(repo.stars)}</span><small>更新于 {formatDate(repo.updatedAt)}</small></div>
-              <div className="install-cell">
-                {progress ? (
-                  <div className={`install-progress ${progress.phase === 'error' ? 'error' : ''} ${indeterminate ? 'indeterminate' : ''}`}>
-                    <div><LoaderCircle className="spin" size={14} /><span>{progress.message}</span><strong>{indeterminate ? '进行中' : `${progress.percent}%`}</strong></div>
-                    <div
-                      className="progress-track"
-                      role="progressbar"
-                      aria-label={progress.message}
-                      aria-valuemin={0}
-                      aria-valuemax={100}
-                      aria-valuenow={indeterminate ? undefined : progress.percent}
-                      aria-valuetext={indeterminate ? '正在进行' : undefined}
-                    ><span style={indeterminate ? undefined : { width: `${progress.percent}%` }} /></div>
-                  </div>
-                ) : installed ? (
-                  <div className="installed-actions">
-                    <span className="installed-label"><Check size={16} />{repo.kind === 'dsh' ? `${dshInstallation.source === 'system' ? '系统 DSH' : '本地 DSH'} ${dshInstallation.version ?? ''}` : '已下载'}</span>
-                    <button type="button" className="install-button update-button" disabled={installing !== null} onClick={() => void install(repo)} title={`检查并更新 ${repo.name}`}>
-                      <RefreshCw size={15} />更新
-                    </button>
-                  </div>
-                ) : (
-                  <button type="button" className="install-button" disabled={installing !== null} onClick={() => void install(repo)}>
-                    {installing === repo.fullName ? <LoaderCircle className="spin" size={16} /> : <Download size={16} />}
-                    {repo.kind === 'dsh' ? '安装 DSH' : '安装'}
-                  </button>
-                )}
-              </div>
-            </article>
-          )
-        })}
-      </section>
-    </div>
-  )
-}
-
-function RuntimeView({ runtime, settings, logs, busy, onToggleRuntime, onOpenHarness, onClearLogs, onOpenSettings }: {
-  runtime: RuntimeState
-  settings: AppSettings
-  logs: RuntimeOutput[]
-  busy: boolean
-  onToggleRuntime: () => void
-  onOpenHarness: () => void
-  onClearLogs: () => void
-  onOpenSettings: () => void
-}) {
-  const logEnd = useRef<HTMLDivElement>(null)
-  useEffect(() => {
-    logEnd.current?.scrollIntoView?.({ block: 'nearest' })
-  }, [logs])
-  return (
-    <div className="page runtime-page">
-      <PageHeading
-        eyebrow="LOCAL RUNTIME"
-        title="运行 DeepSeek Harness"
-        description="从当前工作目录启动 Web 界面，并在这里查看进程状态与实时输出。"
-        actions={<button type="button" className="secondary-button" onClick={onOpenSettings}><Settings size={16} />启动设置</button>}
-      />
-      <section className={`runtime-band ${runtime.running ? 'running' : ''}`}>
-        <div className="runtime-status-icon">{runtime.running ? <CircleCheck size={25} /> : <CircleStop size={25} />}</div>
-        <div className="runtime-copy"><span>{runtime.running ? 'DSH 正在运行' : 'DSH 当前已停止'}</span><strong>{runtime.running ? runtime.url ?? '正在等待 Web 地址…' : '准备从本地启动'}</strong></div>
-        <div className="runtime-metadata"><span>配置 <strong>{settings.profileName}</strong></span><span>{runtime.pid ? `PID ${runtime.pid}` : '无活动进程'}</span></div>
-        {runtime.url && <button type="button" className="secondary-button" onClick={onOpenHarness}>打开工作台<ExternalLink size={15} /></button>}
-        <button type="button" className={`primary-command ${runtime.running ? 'stop' : ''}`} onClick={onToggleRuntime} disabled={busy}>
-          {busy ? <LoaderCircle className="spin" size={17} /> : runtime.running ? <CircleStop size={17} /> : <Play size={17} fill="currentColor" />}
-          {runtime.running ? '停止' : '启动'}
-        </button>
-      </section>
-
-      <div className="launch-facts">
-        <div><span>启动命令</span><code>{settings.launchExecutable} {settings.launchArgs.join(' ')}</code></div>
-        <div><span>工作目录</span><code>{settings.workspace}</code></div>
-        <div><span>DSH_HOME</span><code>{settings.dshHome}</code></div>
-      </div>
-
-      <section className="log-panel">
-        <header><div><SquareTerminal size={17} /><strong>运行日志</strong><span>{logs.length} 条</span></div><button type="button" onClick={onClearLogs} disabled={logs.length === 0}>清空</button></header>
-        <div className="log-output" role="log" aria-live="polite">
-          {logs.length === 0 ? (
-            <div className="log-empty"><SquareTerminal size={22} /><span>启动 DSH 后，输出会显示在这里。</span></div>
-          ) : logs.map((log, index) => (
-            <div className={`log-line ${log.level}`} key={`${log.timestamp}-${index}`}>
-              <time>{new Date(log.timestamp).toLocaleTimeString('zh-CN', { hour12: false })}</time>
-              <span className="log-channel">{log.channel === 'plugin' ? 'PLUGIN' : 'DSH'}</span>
-              <pre>{log.text}</pre>
-            </div>
-          ))}
-          <div ref={logEnd} />
-        </div>
-      </section>
-    </div>
-  )
-}
-
-function PageHeading({ eyebrow, title, description, actions }: { eyebrow: string; title: string; description: string; actions?: React.ReactNode }) {
-  return (
-    <div className="page-heading">
-      <div><span className="eyebrow">{eyebrow}</span><h1>{title}</h1><p>{description}</p></div>
-      {actions && <div className="page-actions">{actions}</div>}
-    </div>
-  )
-}
-
-function CredentialDialog({ status, busy, onClose, onSave, onClear }: {
-  status: CredentialStatus
-  busy: boolean
-  onClose: () => void
-  onSave: (apiKey: string) => void
-  onClear: () => void
-}) {
-  const [apiKey, setApiKey] = useState('')
-  const [visible, setVisible] = useState(false)
-  const [confirmingClear, setConfirmingClear] = useState(false)
-
-  return (
-    <div className="modal-backdrop" role="presentation" onMouseDown={event => { if (event.currentTarget === event.target && !busy) onClose() }}>
-      <form
-        className="modal credential-dialog"
-        aria-modal="true"
-        aria-labelledby="credential-title"
-        role="dialog"
-        onSubmit={event => {
-          event.preventDefault()
-          if (apiKey.trim() && !busy) onSave(apiKey)
-        }}
-      >
-        <header>
-          <div><KeyRound size={19} /><h2 id="credential-title">配置 DeepSeek API Key</h2></div>
-          <button type="button" className="icon-button" onClick={onClose} disabled={busy} aria-label="关闭 Key 配置"><X size={18} /></button>
-        </header>
-        <div className="modal-content">
-          <div className={`credential-summary ${status.configured ? 'configured' : ''}`}>
-            {status.configured ? <CircleCheck size={19} /> : <CircleAlert size={19} />}
-            <div>
-              <strong>{status.configured ? 'DeepSeek Key 已配置' : '尚未配置 DeepSeek Key'}</strong>
-              <span>{status.configured ? '输入新 Key 可直接替换现有值。' : '保存后即可在 DeepSeek Harness 中调用模型。'}</span>
-            </div>
-          </div>
-          <label className="credential-field">
-            <span>API Key</span>
-            <div className="secret-input">
-              <input
-                autoFocus
-                autoComplete="off"
-                type={visible ? 'text' : 'password'}
-                value={apiKey}
-                placeholder={status.configured ? '输入新的 Key 以替换' : '输入 DeepSeek API Key'}
-                spellCheck={false}
-                onChange={event => setApiKey(event.target.value)}
-              />
-              <button
-                type="button"
-                title={visible ? '隐藏 Key' : '显示 Key'}
-                aria-label={visible ? '隐藏 Key' : '显示 Key'}
-                onClick={() => setVisible(current => !current)}
-              >
-                {visible ? <EyeOff size={17} /> : <Eye size={17} />}
-              </button>
-            </div>
-          </label>
-          <p className="credential-privacy">Key 仅写入当前 DSH_HOME 的本机凭据文件。启动器不会回显、记录或上传它。</p>
-        </div>
-        <footer>
-          {status.configured && (
-            <button
-              type="button"
-              className="danger-button clear-key"
-              disabled={busy}
-              onClick={() => confirmingClear ? onClear() : setConfirmingClear(true)}
-            >
-              <Trash2 size={16} />{confirmingClear ? '再次点击确认清除' : '清除 Key'}
-            </button>
-          )}
-          <button type="button" className="secondary-button" onClick={onClose} disabled={busy}>取消</button>
-          <button type="submit" className="primary-command" disabled={busy || !apiKey.trim()}>
-            {busy ? <LoaderCircle className="spin" size={17} /> : <Check size={17} />}
-            {status.configured ? '替换 Key' : '保存 Key'}
-          </button>
-        </footer>
-      </form>
-    </div>
-  )
-}
-
-function SettingsDialog({ settings, busy, onClose, onSave }: {
-  settings: AppSettings
-  busy: boolean
-  onClose: () => void
-  onSave: (settings: AppSettings) => void
-}) {
-  const [draft, setDraft] = useState(settings)
-  const [argsText, setArgsText] = useState(settings.launchArgs.join(' '))
-  const chooseDirectory = async (kind: 'dshHome' | 'workspace') => {
-    const chosen = await api.chooseDirectory(kind)
-    if (chosen) setDraft(current => ({ ...current, [kind]: chosen }))
-  }
-  return (
-    <div className="modal-backdrop" role="presentation" onMouseDown={event => { if (event.currentTarget === event.target) onClose() }}>
-      <section className="modal settings-dialog" role="dialog" aria-modal="true" aria-labelledby="settings-title">
-        <header><div><Settings size={19} /><h2 id="settings-title">启动器设置</h2></div><button type="button" className="icon-button" onClick={onClose} aria-label="关闭设置"><X size={18} /></button></header>
-        <div className="modal-content">
-          <div className="form-section"><h3>DSH 配置</h3><p>启动器直接读取官方 profile，修改后请刷新插件列表。</p></div>
-          <label className="form-field"><span>DSH_HOME</span><div className="path-input"><input value={draft.dshHome} onChange={event => setDraft({ ...draft, dshHome: event.target.value })} /><button type="button" onClick={() => void chooseDirectory('dshHome')} title="选择 DSH_HOME"><Folder size={17} /></button></div></label>
-          <label className="form-field"><span>Profile 名称</span><input value={draft.profileName} onChange={event => setDraft({ ...draft, profileName: event.target.value })} /></label>
-          <div className="form-section divided"><h3>启动命令</h3><p>默认使用官方 npm 包启动 Web 工作台。</p></div>
-          <label className="form-field"><span>可执行文件</span><input value={draft.launchExecutable} onChange={event => setDraft({ ...draft, launchExecutable: event.target.value })} /></label>
-          <label className="form-field"><span>参数</span><input value={argsText} onChange={event => setArgsText(event.target.value)} /></label>
-          <label className="form-field"><span>工作目录</span><div className="path-input"><input value={draft.workspace} onChange={event => setDraft({ ...draft, workspace: event.target.value })} /><button type="button" onClick={() => void chooseDirectory('workspace')} title="选择工作目录"><Folder size={17} /></button></div></label>
-          <label className="check-field"><input type="checkbox" checked={draft.openAfterLaunch} onChange={event => setDraft({ ...draft, openAfterLaunch: event.target.checked })} /><span><strong>启动后打开 Harness</strong><small>识别到本地 Web 地址时，在默认浏览器中打开。</small></span></label>
-        </div>
-        <footer><button type="button" className="secondary-button" onClick={onClose}>取消</button><button type="button" className="primary-command" disabled={busy} onClick={() => onSave({ ...draft, launchArgs: argsText.trim().split(/\s+/).filter(Boolean) })}>{busy ? <LoaderCircle className="spin" size={17} /> : <Check size={17} />}保存设置</button></footer>
-      </section>
-    </div>
-  )
-}
-
-function ConfirmDialog({ plugin, onCancel, onConfirm }: { plugin: ManagedPlugin; onCancel: () => void; onConfirm: () => void }) {
-  return (
-    <div className="modal-backdrop" role="presentation">
-      <section className="modal confirm-dialog" role="alertdialog" aria-modal="true" aria-labelledby="confirm-title">
-        <div className="confirm-icon"><Trash2 size={22} /></div>
-        <h2 id="confirm-title">卸载 {plugin.displayName}？</h2>
-        <p>这会让官方 DSH CLI 从 <strong>web</strong> profile 中移除此依赖。仓库与其他 profile 不受影响。</p>
-        <footer><button type="button" className="secondary-button" onClick={onCancel}>取消</button><button type="button" className="danger-button" onClick={onConfirm}><Trash2 size={16} />确认卸载</button></footer>
-      </section>
-    </div>
-  )
-}
-
-function Toast({ toast, onClose }: { toast: ToastState; onClose: () => void }) {
-  return (
-    <div className={`toast ${toast.kind}`} role="status">
-      {toast.kind === 'success' ? <CircleCheck size={18} /> : <CircleAlert size={18} />}
-      <span>{toast.message}</span>
-      <button type="button" onClick={onClose} aria-label="关闭提示"><X size={15} /></button>
-    </div>
   )
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,23 @@
+import { createContext, useContext } from 'react'
+import { demoApi } from '../demo-api'
+import type { LauncherApi } from '../types'
+
+/**
+ * 渲染层访问主进程的唯一入口。
+ * 通过 context 传递而不是模块级全局，组件因此可以在测试里注入替身。
+ */
+
+/** 在 Electron 里拿真实实现，在浏览器里回落到演示数据。 */
+export function resolveLauncherApi(): LauncherApi {
+  return window.launcher ?? demoApi
+}
+
+const LauncherApiContext = createContext<LauncherApi | null>(null)
+
+export const LauncherApiProvider = LauncherApiContext.Provider
+
+export function useLauncherApi(): LauncherApi {
+  const api = useContext(LauncherApiContext)
+  if (!api) throw new Error('useLauncherApi 必须在 LauncherApiProvider 内部使用。')
+  return api
+}

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,0 +1,76 @@
+import { ArrowLeft, ChevronRight, CircleStop, Download, KeyRound, Layers3, LoaderCircle, Play, Settings, X } from 'lucide-react'
+import type { CredentialStatus, RuntimeState } from '../types'
+
+/** 管理界面顶栏：品牌、当前配置与运行状态、全局动作。 */
+
+interface AppHeaderProps {
+  runtime: RuntimeState
+  busy: boolean
+  dshInstalled: boolean
+  installingDsh: boolean
+  profileName: string
+  credentialStatus: CredentialStatus
+  onBack: () => void
+  onCredential: () => void
+  onSettings: () => void
+  onToggleRuntime: () => void
+  onClose: () => void
+}
+
+export function AppHeader({
+  runtime,
+  busy,
+  dshInstalled,
+  installingDsh,
+  profileName,
+  credentialStatus,
+  onBack,
+  onCredential,
+  onSettings,
+  onToggleRuntime,
+  onClose,
+}: AppHeaderProps) {
+  return (
+    <header className="app-header">
+      <div className="brand-block">
+        <button className="icon-button manager-back" type="button" title="返回启动页" aria-label="返回启动页" onClick={onBack}>
+          <ArrowLeft size={18} />
+        </button>
+        <div className="brand-mark"><Layers3 size={21} strokeWidth={2.2} /></div>
+        <div>
+          <div className="brand-name">DSH Launcher</div>
+          <div className="brand-subtitle">DeepSeek Harness 管理器</div>
+        </div>
+      </div>
+      <div className="header-context">
+        <span className="context-label">配置</span>
+        <strong>{profileName}</strong>
+        <ChevronRight size={14} />
+        <span className={`status-dot ${runtime.running ? 'running' : ''}`} />
+        <span>{runtime.running ? `运行中 · PID ${runtime.pid}` : dshInstalled ? '尚未启动' : '尚未安装'}</span>
+      </div>
+      <div className="header-actions">
+        <button
+          className={`credential-button ${credentialStatus.configured ? 'configured' : ''}`}
+          type="button"
+          title="配置 DeepSeek API Key"
+          onClick={onCredential}
+        >
+          <KeyRound size={17} />
+          <span>DeepSeek Key</span>
+          <span className="credential-state">{credentialStatus.configured ? '已配置' : '未配置'}</span>
+        </button>
+        <button className="icon-button" type="button" title="启动器设置" aria-label="启动器设置" onClick={onSettings}>
+          <Settings size={19} />
+        </button>
+        <button className={`primary-command ${runtime.running ? 'stop' : ''}`} type="button" onClick={onToggleRuntime} disabled={busy}>
+          {busy ? <LoaderCircle className="spin" size={18} /> : runtime.running ? <CircleStop size={18} /> : dshInstalled ? <Play size={18} fill="currentColor" /> : <Download size={18} />}
+          <span>{runtime.running ? '停止 DSH' : installingDsh ? '安装中' : dshInstalled ? '启动 DSH' : '安装 DSH'}</span>
+        </button>
+        <button className="manager-window-close" type="button" title="关闭" aria-label="关闭" onClick={onClose}>
+          <X size={18} />
+        </button>
+      </div>
+    </header>
+  )
+}

--- a/src/components/LauncherHome.tsx
+++ b/src/components/LauncherHome.tsx
@@ -1,0 +1,103 @@
+import { Box, CircleStop, Download, ExternalLink, KeyRound, LoaderCircle, Play, Settings, X } from 'lucide-react'
+import packageMetadata from '../../package.json'
+import type { AppSettings, DshInstallationStatus, InstallProgress, ProfileState, RuntimeState } from '../types'
+
+/** 启动页：无边框小窗口，只暴露最少的几个动作。 */
+
+interface LauncherHomeProps {
+  settings: AppSettings
+  profile: ProfileState
+  runtime: RuntimeState
+  dshInstallation: DshInstallationStatus
+  installProgress: InstallProgress | null
+  busy: boolean
+  installingDsh: boolean
+  onCredential: () => void
+  onManage: () => void
+  onToggleRuntime: () => void
+  onOpenHarness: () => void
+  onClose: () => void
+}
+
+export function LauncherHome({
+  settings,
+  profile,
+  runtime,
+  dshInstallation,
+  installProgress,
+  busy,
+  installingDsh,
+  onCredential,
+  onManage,
+  onToggleRuntime,
+  onOpenHarness,
+  onClose,
+}: LauncherHomeProps) {
+  const needsInstallation = !dshInstallation.installed
+  const runtimeLabel = busy
+    ? installingDsh ? '正在安装' : runtime.running ? '正在停止' : '正在启动'
+    : runtime.running ? runtime.url ? '已就绪' : '正在启动'
+      : needsInstallation ? '尚未安装' : '等待启动'
+
+  return (
+    <div className="launcher-home">
+      <div className="launcher-drag-region" aria-hidden="true" />
+      <button className="launcher-window-close" type="button" title="关闭" aria-label="关闭" onClick={onClose}>
+        <X size={18} />
+      </button>
+
+      <main className="launcher-stage">
+        <div className="launcher-title-block">
+          <span className="launcher-kicker">LOCAL AI WORKSPACE</span>
+          <h1>DeepSeek Harness</h1>
+          <p>{needsInstallation ? '首次部署准备' : `本地 DSH ${dshInstallation.version ?? ''}`} · {profile.activeBundles.length} 个加载层</p>
+        </div>
+
+        <div className="launcher-controls">
+          <div className="launcher-runtime-state">
+            <span className={`launcher-state-dot ${runtime.running ? 'running' : ''}`} />
+            <div><small>运行状态</small><strong>{runtimeLabel}</strong></div>
+            <span>{runtime.running && runtime.pid ? `PID ${runtime.pid}` : settings.profileName}</span>
+          </div>
+
+          <div className="launcher-action-grid">
+            <button
+              type="button"
+              className={`launcher-start-button ${runtime.running ? 'stop' : ''}`}
+              onClick={onToggleRuntime}
+              disabled={busy}
+            >
+              {busy ? <LoaderCircle className="spin" size={24} /> : runtime.running ? <CircleStop size={24} /> : needsInstallation ? <Download size={24} /> : <Play size={25} fill="currentColor" />}
+              <span>
+                <small>{installingDsh ? installProgress?.message ?? '正在准备本地 DSH' : runtime.running ? '结束本地服务' : needsInstallation ? '首次使用需要完成本地部署' : '启动本地工作台'}</small>
+                <strong>{runtime.running ? '停止 DSH' : installingDsh ? installProgress?.indeterminate ? '安装进行中' : `安装 DSH ${installProgress?.percent ?? 0}%` : needsInstallation ? '下载安装 DSH' : '启动 DSH'}</strong>
+              </span>
+            </button>
+            <button type="button" className="launcher-utility-button" onClick={onManage} disabled={busy}><Settings size={17} /><span>管理</span></button>
+            <button type="button" className="launcher-utility-button" onClick={onCredential} disabled={busy}><KeyRound size={17} /><span>API Key</span></button>
+          </div>
+
+          <div className="launcher-profile-row">
+            <span>启动配置</span>
+            <label className="launcher-profile-select">
+              <Box size={15} />
+              <select aria-label="启动配置" value={settings.profileName} onChange={() => undefined}>
+                <option value={settings.profileName}>{settings.profileName}</option>
+              </select>
+            </label>
+            {runtime.url ? (
+              <button type="button" className="launcher-open-button" onClick={onOpenHarness}>打开 Harness<ExternalLink size={13} /></button>
+            ) : (
+              <span className="launcher-runtime-source">{needsInstallation ? '等待部署' : dshInstallation.source === 'system' ? '系统安装' : '启动器安装'}</span>
+            )}
+          </div>
+        </div>
+      </main>
+
+      <footer className="launcher-footer">
+        <span>DSH Launcher {packageMetadata.version}</span>
+        <span>{profile.initialized ? `${profile.plugins.length} 个插件` : 'Profile 等待初始化'}</span>
+      </footer>
+    </div>
+  )
+}

--- a/src/components/PageHeading.tsx
+++ b/src/components/PageHeading.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react'
+
+/** 各页面顶部统一的标题区。 */
+export function PageHeading({ eyebrow, title, description, actions }: {
+  eyebrow: string
+  title: string
+  description: string
+  actions?: ReactNode
+}) {
+  return (
+    <div className="page-heading">
+      <div><span className="eyebrow">{eyebrow}</span><h1>{title}</h1><p>{description}</p></div>
+      {actions && <div className="page-actions">{actions}</div>}
+    </div>
+  )
+}

--- a/src/components/SideNavigation.tsx
+++ b/src/components/SideNavigation.tsx
@@ -1,0 +1,59 @@
+import { Box, Layers3, Sparkles, SquareTerminal } from 'lucide-react'
+import type { ProfileState, RuntimeState, ViewName } from '../types'
+
+/** 管理界面左侧导航与当前 Profile 摘要。 */
+
+interface NavigationEntry {
+  id: ViewName
+  label: string
+  icon: typeof Box
+  count?: number
+}
+
+interface SideNavigationProps {
+  view: ViewName
+  profile: ProfileState
+  runtime: RuntimeState
+  profileName: string
+  onChange: (view: ViewName) => void
+}
+
+export function SideNavigation({ view, profile, runtime, profileName, onChange }: SideNavigationProps) {
+  const entries: NavigationEntry[] = [
+    { id: 'plugins', label: '插件顺序', icon: Layers3, count: profile.plugins.length },
+    { id: 'discover', label: '发现插件', icon: Sparkles },
+    { id: 'runtime', label: '运行与日志', icon: SquareTerminal },
+  ]
+
+  return (
+    <aside className="side-navigation">
+      <nav aria-label="主导航">
+        {entries.map(entry => {
+          const Icon = entry.icon
+          return (
+            <button
+              key={entry.id}
+              type="button"
+              className={view === entry.id ? 'active' : ''}
+              aria-label={entry.label}
+              title={entry.label}
+              onClick={() => onChange(entry.id)}
+            >
+              <Icon size={18} />
+              <span>{entry.label}</span>
+              {entry.count !== undefined && <span className="nav-count">{entry.count}</span>}
+            </button>
+          )
+        })}
+      </nav>
+      <div className="profile-summary">
+        <div className="profile-icon"><Box size={17} /></div>
+        <div className="profile-copy">
+          <strong>{profileName}</strong>
+          <span>{profile.initialized ? `${profile.activeBundles.length} 层已激活` : '等待初始化'}</span>
+        </div>
+        <span className={`mini-status ${runtime.running ? 'running' : ''}`} title={runtime.running ? 'DSH 正在运行' : 'DSH 未运行'} />
+      </div>
+    </aside>
+  )
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,13 @@
+import { CircleAlert, CircleCheck, X } from 'lucide-react'
+import type { ToastState } from '../hooks/use-toast'
+
+/** 右下角的短暂提示条。 */
+export function Toast({ toast, onClose }: { toast: ToastState; onClose: () => void }) {
+  return (
+    <div className={`toast ${toast.kind}`} role="status">
+      {toast.kind === 'success' ? <CircleCheck size={18} /> : <CircleAlert size={18} />}
+      <span>{toast.message}</span>
+      <button type="button" onClick={onClose} aria-label="关闭提示"><X size={15} /></button>
+    </div>
+  )
+}

--- a/src/components/dialogs/ConfirmDialog.tsx
+++ b/src/components/dialogs/ConfirmDialog.tsx
@@ -1,0 +1,20 @@
+import { Trash2 } from 'lucide-react'
+import type { ManagedPlugin } from '../../types'
+
+/** 卸载插件前的确认。 */
+export function ConfirmDialog({ plugin, onCancel, onConfirm }: {
+  plugin: ManagedPlugin
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  return (
+    <div className="modal-backdrop" role="presentation">
+      <section className="modal confirm-dialog" role="alertdialog" aria-modal="true" aria-labelledby="confirm-title">
+        <div className="confirm-icon"><Trash2 size={22} /></div>
+        <h2 id="confirm-title">卸载 {plugin.displayName}？</h2>
+        <p>这会让官方 DSH CLI 从 <strong>web</strong> profile 中移除此依赖。仓库与其他 profile 不受影响。</p>
+        <footer><button type="button" className="secondary-button" onClick={onCancel}>取消</button><button type="button" className="danger-button" onClick={onConfirm}><Trash2 size={16} />确认卸载</button></footer>
+      </section>
+    </div>
+  )
+}

--- a/src/components/dialogs/CredentialDialog.tsx
+++ b/src/components/dialogs/CredentialDialog.tsx
@@ -1,0 +1,88 @@
+import { Check, CircleAlert, CircleCheck, Eye, EyeOff, KeyRound, LoaderCircle, Trash2, X } from 'lucide-react'
+import { useState } from 'react'
+import type { CredentialStatus } from '../../types'
+
+/** DeepSeek API Key 的配置与清除。Key 只向下写入，不回显。 */
+
+interface CredentialDialogProps {
+  status: CredentialStatus
+  busy: boolean
+  onClose: () => void
+  onSave: (apiKey: string) => void
+  onClear: () => void
+}
+
+export function CredentialDialog({ status, busy, onClose, onSave, onClear }: CredentialDialogProps) {
+  const [apiKey, setApiKey] = useState('')
+  const [visible, setVisible] = useState(false)
+  const [confirmingClear, setConfirmingClear] = useState(false)
+
+  return (
+    <div className="modal-backdrop" role="presentation" onMouseDown={event => { if (event.currentTarget === event.target && !busy) onClose() }}>
+      <form
+        className="modal credential-dialog"
+        aria-modal="true"
+        aria-labelledby="credential-title"
+        role="dialog"
+        onSubmit={event => {
+          event.preventDefault()
+          if (apiKey.trim() && !busy) onSave(apiKey)
+        }}
+      >
+        <header>
+          <div><KeyRound size={19} /><h2 id="credential-title">配置 DeepSeek API Key</h2></div>
+          <button type="button" className="icon-button" onClick={onClose} disabled={busy} aria-label="关闭 Key 配置"><X size={18} /></button>
+        </header>
+        <div className="modal-content">
+          <div className={`credential-summary ${status.configured ? 'configured' : ''}`}>
+            {status.configured ? <CircleCheck size={19} /> : <CircleAlert size={19} />}
+            <div>
+              <strong>{status.configured ? 'DeepSeek Key 已配置' : '尚未配置 DeepSeek Key'}</strong>
+              <span>{status.configured ? '输入新 Key 可直接替换现有值。' : '保存后即可在 DeepSeek Harness 中调用模型。'}</span>
+            </div>
+          </div>
+          <label className="credential-field">
+            <span>API Key</span>
+            <div className="secret-input">
+              <input
+                autoFocus
+                autoComplete="off"
+                type={visible ? 'text' : 'password'}
+                value={apiKey}
+                placeholder={status.configured ? '输入新的 Key 以替换' : '输入 DeepSeek API Key'}
+                spellCheck={false}
+                onChange={event => setApiKey(event.target.value)}
+              />
+              <button
+                type="button"
+                title={visible ? '隐藏 Key' : '显示 Key'}
+                aria-label={visible ? '隐藏 Key' : '显示 Key'}
+                onClick={() => setVisible(current => !current)}
+              >
+                {visible ? <EyeOff size={17} /> : <Eye size={17} />}
+              </button>
+            </div>
+          </label>
+          <p className="credential-privacy">Key 仅写入当前 DSH_HOME 的本机凭据文件。启动器不会回显、记录或上传它。</p>
+        </div>
+        <footer>
+          {status.configured && (
+            <button
+              type="button"
+              className="danger-button clear-key"
+              disabled={busy}
+              onClick={() => confirmingClear ? onClear() : setConfirmingClear(true)}
+            >
+              <Trash2 size={16} />{confirmingClear ? '再次点击确认清除' : '清除 Key'}
+            </button>
+          )}
+          <button type="button" className="secondary-button" onClick={onClose} disabled={busy}>取消</button>
+          <button type="submit" className="primary-command" disabled={busy || !apiKey.trim()}>
+            {busy ? <LoaderCircle className="spin" size={17} /> : <Check size={17} />}
+            {status.configured ? '替换 Key' : '保存 Key'}
+          </button>
+        </footer>
+      </form>
+    </div>
+  )
+}

--- a/src/components/dialogs/SettingsDialog.tsx
+++ b/src/components/dialogs/SettingsDialog.tsx
@@ -1,0 +1,44 @@
+import { Check, Folder, LoaderCircle, Settings, X } from 'lucide-react'
+import { useState } from 'react'
+import { useLauncherApi } from '../../api/client'
+import type { AppSettings } from '../../types'
+
+/** 启动器设置：DSH_HOME、Profile、启动命令与工作目录。 */
+
+interface SettingsDialogProps {
+  settings: AppSettings
+  busy: boolean
+  onClose: () => void
+  onSave: (settings: AppSettings) => void
+}
+
+export function SettingsDialog({ settings, busy, onClose, onSave }: SettingsDialogProps) {
+  const api = useLauncherApi()
+  const [draft, setDraft] = useState(settings)
+  // 参数在界面上是一整行文本，保存时才切成数组。
+  const [argsText, setArgsText] = useState(settings.launchArgs.join(' '))
+
+  const chooseDirectory = async (kind: 'dshHome' | 'workspace') => {
+    const chosen = await api.chooseDirectory(kind)
+    if (chosen) setDraft(current => ({ ...current, [kind]: chosen }))
+  }
+
+  return (
+    <div className="modal-backdrop" role="presentation" onMouseDown={event => { if (event.currentTarget === event.target) onClose() }}>
+      <section className="modal settings-dialog" role="dialog" aria-modal="true" aria-labelledby="settings-title">
+        <header><div><Settings size={19} /><h2 id="settings-title">启动器设置</h2></div><button type="button" className="icon-button" onClick={onClose} aria-label="关闭设置"><X size={18} /></button></header>
+        <div className="modal-content">
+          <div className="form-section"><h3>DSH 配置</h3><p>启动器直接读取官方 profile，修改后请刷新插件列表。</p></div>
+          <label className="form-field"><span>DSH_HOME</span><div className="path-input"><input value={draft.dshHome} onChange={event => setDraft({ ...draft, dshHome: event.target.value })} /><button type="button" onClick={() => void chooseDirectory('dshHome')} title="选择 DSH_HOME"><Folder size={17} /></button></div></label>
+          <label className="form-field"><span>Profile 名称</span><input value={draft.profileName} onChange={event => setDraft({ ...draft, profileName: event.target.value })} /></label>
+          <div className="form-section divided"><h3>启动命令</h3><p>默认使用官方 npm 包启动 Web 工作台。</p></div>
+          <label className="form-field"><span>可执行文件</span><input value={draft.launchExecutable} onChange={event => setDraft({ ...draft, launchExecutable: event.target.value })} /></label>
+          <label className="form-field"><span>参数</span><input value={argsText} onChange={event => setArgsText(event.target.value)} /></label>
+          <label className="form-field"><span>工作目录</span><div className="path-input"><input value={draft.workspace} onChange={event => setDraft({ ...draft, workspace: event.target.value })} /><button type="button" onClick={() => void chooseDirectory('workspace')} title="选择工作目录"><Folder size={17} /></button></div></label>
+          <label className="check-field"><input type="checkbox" checked={draft.openAfterLaunch} onChange={event => setDraft({ ...draft, openAfterLaunch: event.target.checked })} /><span><strong>启动后打开 Harness</strong><small>识别到本地 Web 地址时，在默认浏览器中打开。</small></span></label>
+        </div>
+        <footer><button type="button" className="secondary-button" onClick={onClose}>取消</button><button type="button" className="primary-command" disabled={busy} onClick={() => onSave({ ...draft, launchArgs: argsText.trim().split(/\s+/).filter(Boolean) })}>{busy ? <LoaderCircle className="spin" size={17} /> : <Check size={17} />}保存设置</button></footer>
+      </section>
+    </div>
+  )
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,52 @@
+// 主进程与渲染进程共享的常量。
+// 与 types.ts 一样，这个文件是两侧的公共契约 —— 任何一侧单独持有副本都会随时间漂移。
+
+/** DSH 本体的 GitHub 仓库。出现在插件列表中时按本体而非普通插件处理。 */
+export const DSH_REPOSITORY = 'deepseek-ai/deepseek-harness'
+
+/** DSH 本体的 npm 包名。检测与安装都以它为准。 */
+export const DSH_PACKAGE_NAME = '@deepseek-ai/dsh'
+
+/** 未显式配置时使用的 Profile。 */
+export const DEFAULT_PROFILE_NAME = 'web'
+
+/** 渲染层保留的最大日志条数，超出后丢弃最旧的记录。 */
+export const MAX_LOG_LINES = 500
+
+/** 尚未取到主进程状态时的占位值。 */
+export const EMPTY_RUNTIME_STATE = { running: false, pid: null, startedAt: null, url: null } as const
+export const EMPTY_DSH_INSTALLATION = { installed: false, version: null, executable: null, source: null } as const
+
+/**
+ * IPC 通道名。主进程注册与 preload 调用共用这一份定义 ——
+ * 此前两侧各写一遍字面量，改名时很容易只改一边。
+ */
+export const IPC = {
+  settingsGet: 'settings:get',
+  settingsSave: 'settings:save',
+  dshDetect: 'dsh:detect-installation',
+  credentialStatus: 'credentials:deepseek-status',
+  credentialSet: 'credentials:deepseek-set',
+  credentialClear: 'credentials:deepseek-clear',
+  chooseDirectory: 'dialog:directory',
+  profileRead: 'profile:read',
+  profileToggle: 'profile:toggle',
+  profileReorder: 'profile:reorder',
+  pluginsDiscover: 'plugins:discover',
+  pluginsInstall: 'plugins:install',
+  pluginsUninstall: 'plugins:uninstall',
+  runtimeState: 'runtime:state',
+  runtimeStart: 'runtime:start',
+  runtimeStop: 'runtime:stop',
+  openExternal: 'shell:open-external',
+  openPath: 'shell:open-path',
+  windowSetMode: 'window:set-mode',
+  windowClose: 'window:close',
+} as const
+
+/** 主进程主动推送给渲染层的事件通道。 */
+export const IPC_EVENTS = {
+  runtimeOutput: 'runtime:output',
+  runtimeStateChanged: 'runtime:state-changed',
+  installProgress: 'plugins:install-progress',
+} as const

--- a/src/hooks/use-async-action.ts
+++ b/src/hooks/use-async-action.ts
@@ -1,0 +1,56 @@
+import { useCallback, useState } from 'react'
+import { errorText } from '../lib/format'
+import type { ToastState } from './use-toast'
+
+/**
+ * 「标记忙碌 → 执行 → 成功提示 / 失败提示 → 解除忙碌」这套流程
+ * 原本在六个动作里各写了一遍。这里收敛为一处。
+ *
+ * busy 保存的是当前忙碌动作的标识，组件据此只禁用相关按钮而不是整个界面。
+ */
+
+/** 全局动作的忙碌标识。插件级动作直接用包名。 */
+export const BUSY = {
+  runtime: 'runtime',
+  dshInstall: 'dsh-install',
+  settings: 'settings',
+  credential: 'credential',
+  reorder: 'reorder',
+} as const
+
+export interface RunOptions<T> {
+  /** 成功后的提示文案，可根据结果动态生成。 */
+  success?: string | ((result: T) => string)
+  /** 自定义失败处理；不提供则默认弹出错误提示。 */
+  onError?: (error: unknown) => void
+}
+
+export function useAsyncAction(showToast: (toast: ToastState) => void) {
+  const [busy, setBusy] = useState<string | null>(null)
+
+  const run = useCallback(async <T>(
+    key: string,
+    action: () => Promise<T>,
+    options: RunOptions<T> = {},
+  ): Promise<T | undefined> => {
+    setBusy(key)
+    try {
+      const result = await action()
+      if (options.success !== undefined) {
+        showToast({
+          kind: 'success',
+          message: typeof options.success === 'function' ? options.success(result) : options.success,
+        })
+      }
+      return result
+    } catch (error) {
+      if (options.onError) options.onError(error)
+      else showToast({ kind: 'error', message: errorText(error) })
+      return undefined
+    } finally {
+      setBusy(null)
+    }
+  }, [showToast])
+
+  return { busy, run }
+}

--- a/src/hooks/use-launcher-store.ts
+++ b/src/hooks/use-launcher-store.ts
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useLauncherApi } from '../api/client'
+import { DSH_REPOSITORY, EMPTY_DSH_INSTALLATION, EMPTY_RUNTIME_STATE, MAX_LOG_LINES } from '../constants'
+import { errorText } from '../lib/format'
+import { reorderProfilePlugins } from '../lib/profile-order'
+import type {
+  AppSettings,
+  CredentialStatus,
+  DshInstallationStatus,
+  InstallProgress,
+  ManagedPlugin,
+  ProfileState,
+  RepositoryInstallResult,
+  RuntimeOutput,
+  RuntimeState,
+} from '../types'
+import { BUSY, useAsyncAction } from './use-async-action'
+import { useToast } from './use-toast'
+
+/**
+ * 启动器的领域状态与全部写操作。
+ * 界面导航、对话框开关等纯展示状态不在这里 —— 那些由 App 自己持有。
+ */
+
+/** toggleRuntime 的结果，调用方据此决定是否切换到日志视图。 */
+export type RuntimeToggleResult = 'installed' | 'started' | 'stopped' | 'failed'
+
+export function useLauncherStore() {
+  const api = useLauncherApi()
+  const { toast, showToast, dismissToast } = useToast()
+  const { busy, run } = useAsyncAction(showToast)
+
+  const [settings, setSettings] = useState<AppSettings | null>(null)
+  const [profile, setProfile] = useState<ProfileState | null>(null)
+  const [runtime, setRuntime] = useState<RuntimeState>(EMPTY_RUNTIME_STATE)
+  const [dshInstallation, setDshInstallation] = useState<DshInstallationStatus>(EMPTY_DSH_INSTALLATION)
+  const [installProgress, setInstallProgress] = useState<InstallProgress | null>(null)
+  const [credentialStatus, setCredentialStatus] = useState<CredentialStatus>({ configured: false })
+  const [logs, setLogs] = useState<RuntimeOutput[]>([])
+  const [selectedPlugin, setSelectedPlugin] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  /** 保留原选中项；它已不存在时退回列表首项。 */
+  const adoptProfile = useCallback((next: ProfileState) => {
+    setProfile(next)
+    setSelectedPlugin(current => current && next.plugins.some(plugin => plugin.packageName === current)
+      ? current
+      : next.plugins[0]?.packageName ?? null)
+  }, [])
+
+  useEffect(() => {
+    void Promise.all([
+      api.getSettings(),
+      api.readProfile(),
+      api.getRuntimeState(),
+      api.getDeepSeekCredentialStatus(),
+      api.detectDshInstallation(),
+    ])
+      .then(([nextSettings, nextProfile, nextRuntime, nextCredentialStatus, nextDshInstallation]) => {
+        setSettings(nextSettings)
+        setProfile(nextProfile)
+        setRuntime(nextRuntime)
+        setCredentialStatus(nextCredentialStatus)
+        setDshInstallation(nextDshInstallation)
+        setSelectedPlugin(nextProfile.plugins[0]?.packageName ?? null)
+      })
+      .catch(error => showToast({ kind: 'error', message: errorText(error) }))
+      .finally(() => setLoading(false))
+
+    const unsubscribers = [
+      api.onRuntimeOutput(output => setLogs(current => [...current.slice(-(MAX_LOG_LINES - 1)), output])),
+      api.onRuntimeState(setRuntime),
+      api.onInstallProgress(setInstallProgress),
+    ]
+    return () => unsubscribers.forEach(unsubscribe => unsubscribe())
+  }, [api, showToast])
+
+  const refreshProfile = useCallback(async () => {
+    try {
+      adoptProfile(await api.readProfile())
+    } catch (error) {
+      showToast({ kind: 'error', message: errorText(error) })
+    }
+  }, [adoptProfile, api, showToast])
+
+  /** 安装完成后一次性同步受影响的几处状态。 */
+  const applyInstallResult = useCallback((result: RepositoryInstallResult) => {
+    setSettings(result.settings)
+    adoptProfile(result.profile)
+    setDshInstallation(result.dshInstallation)
+  }, [adoptProfile])
+
+  /**
+   * 首页主按钮。尚未安装 DSH 时先完成部署，之后才是启动/停止。
+   */
+  const toggleRuntime = useCallback(async (): Promise<RuntimeToggleResult> => {
+    const needsInstallation = !runtime.running && !dshInstallation.installed
+    if (needsInstallation) {
+      setInstallProgress({
+        repository: DSH_REPOSITORY,
+        kind: 'dsh',
+        phase: 'preparing',
+        percent: 0,
+        message: '正在准备本地 DSH',
+      })
+      const result = await run(BUSY.dshInstall, () => api.installPlugin(DSH_REPOSITORY), {
+        success: installed => `本地 DSH ${installed.dshInstallation.version ?? ''} 已安装，可以启动。`,
+      })
+      if (!result) return 'failed'
+      applyInstallResult(result)
+      return 'installed'
+    }
+
+    const wasRunning = runtime.running
+    const next = await run(BUSY.runtime, () => wasRunning ? api.stopRuntime() : api.startRuntime())
+    if (!next) return 'failed'
+    setRuntime(next)
+    return wasRunning ? 'stopped' : 'started'
+  }, [api, applyInstallResult, dshInstallation.installed, run, runtime.running])
+
+  const saveSettings = useCallback(async (next: AppSettings): Promise<boolean> => {
+    const saved = await run(BUSY.settings, async () => {
+      const stored = await api.saveSettings(next)
+      setSettings(stored)
+      setDshInstallation(await api.detectDshInstallation())
+      setCredentialStatus(await api.getDeepSeekCredentialStatus())
+      await refreshProfile()
+      return stored
+    }, { success: '设置已保存。' })
+    return saved !== undefined
+  }, [api, refreshProfile, run])
+
+  const saveApiKey = useCallback(async (apiKey: string): Promise<boolean> => {
+    const status = await run(BUSY.credential, () => api.setDeepSeekApiKey(apiKey), {
+      success: 'DeepSeek API Key 已保存，DSH 可立即使用。',
+    })
+    if (!status) return false
+    setCredentialStatus(status)
+    return true
+  }, [api, run])
+
+  const clearApiKey = useCallback(async (): Promise<boolean> => {
+    const status = await run(BUSY.credential, () => api.clearDeepSeekApiKey(), {
+      success: 'DeepSeek API Key 已清除。',
+    })
+    if (!status) return false
+    setCredentialStatus(status)
+    return true
+  }, [api, run])
+
+  const togglePlugin = useCallback(async (plugin: ManagedPlugin, enabled: boolean) => {
+    const next = await run(plugin.packageName, () => api.togglePlugin(plugin.packageName, enabled), {
+      success: enabled ? '插件将在下次启动时加载。' : '插件已停用，但仍保留在本机。',
+    })
+    if (next) setProfile(next)
+  }, [api, run])
+
+  /** 先本地重排让拖拽有即时反馈，主进程写盘失败再回滚。 */
+  const reorderPlugins = useCallback(async (packageNames: string[]) => {
+    if (!profile) return
+    const previous = profile
+    setProfile(reorderProfilePlugins(profile, packageNames))
+    const next = await run(BUSY.reorder, () => api.reorderPlugins(packageNames), {
+      onError: error => {
+        setProfile(previous)
+        showToast({ kind: 'error', message: errorText(error) })
+      },
+    })
+    if (next) setProfile(next)
+  }, [api, profile, run, showToast])
+
+  const uninstallPlugin = useCallback(async (plugin: ManagedPlugin) => {
+    const next = await run(plugin.packageName, () => api.uninstallPlugin(plugin.packageName), {
+      success: `${plugin.displayName} 已卸载。`,
+    })
+    if (!next) return
+    setProfile(next)
+    setSelectedPlugin(next.plugins[0]?.packageName ?? null)
+  }, [api, run])
+
+  return {
+    // 状态
+    loading,
+    settings,
+    profile,
+    runtime,
+    dshInstallation,
+    installProgress,
+    credentialStatus,
+    logs,
+    selectedPlugin,
+    selected: profile?.plugins.find(plugin => plugin.packageName === selectedPlugin) ?? null,
+    busy,
+    toast,
+
+    // 动作
+    selectPlugin: setSelectedPlugin,
+    clearLogs: () => setLogs([]),
+    dismissToast,
+    showToast,
+    refreshProfile,
+    applyInstallResult,
+    toggleRuntime,
+    saveSettings,
+    saveApiKey,
+    clearApiKey,
+    togglePlugin,
+    reorderPlugins,
+    uninstallPlugin,
+  }
+}
+
+export type LauncherStore = ReturnType<typeof useLauncherStore>

--- a/src/hooks/use-navigation.ts
+++ b/src/hooks/use-navigation.ts
@@ -1,0 +1,27 @@
+import { useCallback, useState } from 'react'
+import { useLauncherApi } from '../api/client'
+import { errorText } from '../lib/format'
+import type { ViewName, WindowMode } from '../types'
+
+/**
+ * 界面导航。切换 surface 时窗口尺寸也要跟着变，
+ * 这个副作用属于导航本身，因此和导航状态放在一起。
+ */
+export function useNavigation(onError: (message: string) => void) {
+  const api = useLauncherApi()
+  const [surface, setSurface] = useState<WindowMode>('launcher')
+  const [view, setView] = useState<ViewName>('plugins')
+
+  const changeSurface = useCallback((next: WindowMode) => {
+    setSurface(next)
+    void api.setWindowMode(next).catch(error => onError(errorText(error)))
+  }, [api, onError])
+
+  return {
+    surface,
+    view,
+    setView,
+    showManager: useCallback(() => changeSurface('manager'), [changeSurface]),
+    showLauncher: useCallback(() => changeSurface('launcher'), [changeSurface]),
+  }
+}

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export interface ToastState {
+  kind: 'success' | 'error'
+  message: string
+}
+
+const TOAST_DURATION = 4200
+
+/** 短暂提示条。同一时刻只显示一条，新提示会顶掉旧的并重置计时。 */
+export function useToast() {
+  const [toast, setToast] = useState<ToastState | null>(null)
+  const timer = useRef<number | null>(null)
+
+  const clearTimer = () => {
+    if (timer.current !== null) {
+      window.clearTimeout(timer.current)
+      timer.current = null
+    }
+  }
+
+  const showToast = useCallback((next: ToastState) => {
+    clearTimer()
+    setToast(next)
+    timer.current = window.setTimeout(() => {
+      timer.current = null
+      setToast(current => (current === next ? null : current))
+    }, TOAST_DURATION)
+  }, [])
+
+  const dismissToast = useCallback(() => {
+    clearTimer()
+    setToast(null)
+  }, [])
+
+  useEffect(() => clearTimer, [])
+
+  return { toast, showToast, dismissToast }
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,31 @@
+import type { ManagedPlugin } from '../types'
+
+/** 把值转成给人看的字符串。全部为纯函数，时间相关的依赖由调用方注入。 */
+
+/** 1200 → "1.2k"。 */
+export function formatStars(value: number): string {
+  if (value >= 1000) return `${(value / 1000).toFixed(1)}k`
+  return String(value)
+}
+
+/** ISO 时间串 → "3 分钟前" / "2 天前" / "8月14日"。 */
+export function formatRelativeTime(value: string, now: number = Date.now()): string {
+  const diff = now - new Date(value).getTime()
+  const minutes = Math.max(1, Math.floor(diff / 60_000))
+  if (minutes < 60) return `${minutes} 分钟前`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours} 小时前`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days} 天前`
+  return new Intl.DateTimeFormat('zh-CN', { month: 'short', day: 'numeric' }).format(new Date(value))
+}
+
+/** 插件列表里的方块头像文字。 */
+export function pluginInitial(plugin: ManagedPlugin): string {
+  return plugin.displayName.trim().slice(0, 2).toUpperCase()
+}
+
+/** 把任意抛出物转成可展示的文案。 */
+export function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/src/lib/profile-order.ts
+++ b/src/lib/profile-order.ts
@@ -1,0 +1,43 @@
+import type { ProfileState } from '../types'
+
+/**
+ * 按新的加载顺序重排 Profile。
+ * 拖拽时先本地应用一次，等主进程写盘返回后再用真实结果覆盖 ——
+ * 失败则回滚到调用前的快照。
+ */
+export function reorderProfilePlugins(profile: ProfileState, packageNames: string[]): ProfileState {
+  const orderByName = new Map(packageNames.map((name, index) => [name, index + 1]))
+  const fallbackOrder = 999
+
+  return {
+    ...profile,
+    activeBundles: packageNames,
+    plugins: [...profile.plugins]
+      .sort((a, b) => {
+        if (a.enabled !== b.enabled) return a.enabled ? -1 : 1
+        return (orderByName.get(a.packageName) ?? fallbackOrder) - (orderByName.get(b.packageName) ?? fallbackOrder)
+      })
+      .map(plugin => ({ ...plugin, order: orderByName.get(plugin.packageName) ?? null })),
+  }
+}
+
+/** 在有序列表里把某一项朝一个方向挪一格，越界时返回 null。 */
+export function movePackage(packageNames: string[], packageName: string, direction: -1 | 1): string[] | null {
+  const names = [...packageNames]
+  const index = names.indexOf(packageName)
+  const target = index + direction
+  if (index < 0 || target < 0 || target >= names.length) return null
+  ;[names[index], names[target]] = [names[target], names[index]]
+  return names
+}
+
+/** 把 dragged 项插入到 target 项的位置，无法完成时返回 null。 */
+export function movePackageTo(packageNames: string[], dragged: string, target: string): string[] | null {
+  if (dragged === target) return null
+  const names = [...packageNames]
+  const from = names.indexOf(dragged)
+  const to = names.indexOf(target)
+  if (from < 0 || to < 0) return null
+  names.splice(to, 0, names.splice(from, 1)[0])
+  return names
+}

--- a/src/views/DiscoverView.tsx
+++ b/src/views/DiscoverView.tsx
@@ -1,0 +1,171 @@
+import {
+  Check,
+  CircleAlert,
+  Clock3,
+  Download,
+  ExternalLink,
+  Github,
+  Layers3,
+  LoaderCircle,
+  RefreshCw,
+  Search,
+  Star,
+  X,
+} from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useLauncherApi } from '../api/client'
+import { PageHeading } from '../components/PageHeading'
+import { EMPTY_DSH_INSTALLATION } from '../constants'
+import { errorText, formatRelativeTime, formatStars } from '../lib/format'
+import type {
+  DshInstallationStatus,
+  InstallProgress,
+  ProfileState,
+  RepositoryInstallResult,
+  RepositoryResult,
+} from '../types'
+
+/** 插件发现页：检索 GitHub 上的 dsh-plugin 仓库并安装。 */
+
+interface DiscoverViewProps {
+  profile: ProfileState
+  onInstalled: (result: RepositoryInstallResult) => void
+  onError: (message: string) => void
+  onOpenRepository: (url: string) => void
+}
+
+export function DiscoverView({ profile, onInstalled, onError, onOpenRepository }: DiscoverViewProps) {
+  const api = useLauncherApi()
+  const [query, setQuery] = useState('')
+  const [sort, setSort] = useState<'stars' | 'updated'>('stars')
+  const [repositories, setRepositories] = useState<RepositoryResult[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [installing, setInstalling] = useState<string | null>(null)
+  const [installProgress, setInstallProgress] = useState<InstallProgress | null>(null)
+  const [dshInstallation, setDshInstallation] = useState<DshInstallationStatus>(EMPTY_DSH_INSTALLATION)
+
+  const search = useCallback(async (searchQuery = query, searchSort = sort) => {
+    setLoading(true)
+    try {
+      const result = await api.discoverPlugins(searchQuery, searchSort)
+      setRepositories(result.repositories)
+      setTotal(result.totalCount)
+      setDshInstallation(result.dshInstallation)
+    } catch (error) {
+      onError(errorText(error))
+    } finally {
+      setLoading(false)
+    }
+  }, [api, onError, query, sort])
+
+  // 首次进入时先拉一屏热门插件；后续检索由用户触发。
+  useEffect(() => { void search('', 'stars') }, [])
+  useEffect(() => api.onInstallProgress(setInstallProgress), [api])
+
+  const installedRepos = useMemo(
+    () => new Set(profile.plugins.map(plugin => plugin.repositoryFullName?.toLowerCase()).filter(Boolean)),
+    [profile.plugins],
+  )
+
+  const install = async (repo: RepositoryResult) => {
+    setInstalling(repo.fullName)
+    setInstallProgress({
+      repository: repo.fullName,
+      kind: repo.kind,
+      phase: 'preparing',
+      percent: 0,
+      message: repo.kind === 'dsh' ? '正在准备本地 DSH' : '正在准备安装插件',
+    })
+    try {
+      const result = await api.installPlugin(repo.fullName)
+      setDshInstallation(result.dshInstallation)
+      onInstalled(result)
+    } catch (error) {
+      onError(errorText(error))
+    } finally {
+      setInstalling(null)
+    }
+  }
+
+  return (
+    <div className="page discover-page">
+      <PageHeading
+        eyebrow="GITHUB CATALOG"
+        title="发现 DSH 插件"
+        description={`从 GitHub dsh-plugin 主题中浏览 ${total ? total.toLocaleString('zh-CN') : ''} 个公开仓库。安装前请检查仓库说明与来源。`}
+      />
+      <div className="discovery-controls">
+        <form className="search-field large" onSubmit={event => { event.preventDefault(); void search() }}>
+          <Search size={18} />
+          <input value={query} onChange={event => setQuery(event.target.value)} placeholder="搜索名称、作者或说明" aria-label="搜索插件" />
+          {query && <button type="button" onClick={() => { setQuery(''); void search('', sort) }} aria-label="清除搜索"><X size={16} /></button>}
+          <button type="submit" className="search-submit">搜索</button>
+        </form>
+        <div className="segmented-control" aria-label="插件排序方式">
+          <button type="button" className={sort === 'stars' ? 'active' : ''} onClick={() => { setSort('stars'); void search(query, 'stars') }}><Star size={15} />热门</button>
+          <button type="button" className={sort === 'updated' ? 'active' : ''} onClick={() => { setSort('updated'); void search(query, 'updated') }}><Clock3 size={15} />最近更新</button>
+        </div>
+      </div>
+
+      <div className="catalog-note"><CircleAlert size={16} /><span>GitHub 主题表示仓库自我声明为 DSH 插件；官方 <code>deepseek-ai/deepseek-harness</code> 会作为 DSH 本体安装到启动器的本地运行目录。</span></div>
+      <section className="repository-list" aria-busy={loading}>
+        <div className="repository-headings" aria-hidden="true"><span>仓库</span><span>语言</span><span>活跃度</span><span /></div>
+        {loading ? (
+          <div className="list-loading"><LoaderCircle className="spin" size={21} />正在读取 GitHub 目录</div>
+        ) : repositories.length === 0 ? (
+          <div className="list-loading"><Search size={21} />没有找到匹配的仓库</div>
+        ) : repositories.map(repo => {
+          const installed = repo.kind === 'dsh' ? dshInstallation.installed : installedRepos.has(repo.fullName.toLowerCase())
+          const progress = installing === repo.fullName && installProgress?.repository === repo.fullName ? installProgress : null
+          const indeterminate = progress?.indeterminate === true && progress.phase !== 'error'
+          return (
+            <article className={`repository-row ${repo.kind === 'dsh' ? 'dsh-core-row' : ''}`} key={repo.id}>
+              <div className="repo-main">
+                <div className={`repo-icon ${repo.kind === 'dsh' ? 'dsh-core-icon' : ''}`}>{repo.kind === 'dsh' ? <Layers3 size={18} /> : <Github size={18} />}</div>
+                <div>
+                  <div className="repo-title-line">
+                    <button type="button" className="repo-title" onClick={() => onOpenRepository(repo.url)}><span>{repo.owner}/</span><strong>{repo.name}</strong><ExternalLink size={13} /></button>
+                    {repo.kind === 'dsh' && <span className="dsh-core-badge">DSH 本体</span>}
+                  </div>
+                  <p>{repo.description}</p>
+                  <div className="topic-list">{repo.topics.slice(0, 3).map(topic => <span key={topic}>{topic}</span>)}</div>
+                </div>
+              </div>
+              <div className="language-cell"><i className={`language-dot lang-${(repo.language ?? 'other').toLowerCase()}`} />{repo.language ?? '其他'}</div>
+              <div className="activity-cell"><span><Star size={15} fill="currentColor" />{formatStars(repo.stars)}</span><small>更新于 {formatRelativeTime(repo.updatedAt)}</small></div>
+              <div className="install-cell">
+                {progress ? (
+                  <div className={`install-progress ${progress.phase === 'error' ? 'error' : ''} ${indeterminate ? 'indeterminate' : ''}`}>
+                    <div><LoaderCircle className="spin" size={14} /><span>{progress.message}</span><strong>{indeterminate ? '进行中' : `${progress.percent}%`}</strong></div>
+                    <div
+                      className="progress-track"
+                      role="progressbar"
+                      aria-label={progress.message}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                      aria-valuenow={indeterminate ? undefined : progress.percent}
+                      aria-valuetext={indeterminate ? '正在进行' : undefined}
+                    ><span style={indeterminate ? undefined : { width: `${progress.percent}%` }} /></div>
+                  </div>
+                ) : installed ? (
+                  <div className="installed-actions">
+                    <span className="installed-label"><Check size={16} />{repo.kind === 'dsh' ? `${dshInstallation.source === 'system' ? '系统 DSH' : '本地 DSH'} ${dshInstallation.version ?? ''}` : '已下载'}</span>
+                    <button type="button" className="install-button update-button" disabled={installing !== null} onClick={() => void install(repo)} title={`检查并更新 ${repo.name}`}>
+                      <RefreshCw size={15} />更新
+                    </button>
+                  </div>
+                ) : (
+                  <button type="button" className="install-button" disabled={installing !== null} onClick={() => void install(repo)}>
+                    {installing === repo.fullName ? <LoaderCircle className="spin" size={16} /> : <Download size={16} />}
+                    {repo.kind === 'dsh' ? '安装 DSH' : '安装'}
+                  </button>
+                )}
+              </div>
+            </article>
+          )
+        })}
+      </section>
+    </div>
+  )
+}

--- a/src/views/PluginsView.tsx
+++ b/src/views/PluginsView.tsx
@@ -1,0 +1,256 @@
+import {
+  ArrowDown,
+  ArrowUp,
+  CircleAlert,
+  Download,
+  ExternalLink,
+  Folder,
+  Github,
+  GripVertical,
+  LoaderCircle,
+  PackageCheck,
+  RefreshCw,
+  Search,
+  SlidersHorizontal,
+  Sparkles,
+  Trash2,
+  X,
+} from 'lucide-react'
+import { useState } from 'react'
+import { PageHeading } from '../components/PageHeading'
+import { pluginInitial } from '../lib/format'
+import { movePackage, movePackageTo } from '../lib/profile-order'
+import type { ManagedPlugin, ProfileState } from '../types'
+
+/** 插件加载顺序页：列表、排序、启停与详情。 */
+
+interface PluginsViewProps {
+  profile: ProfileState
+  selected: ManagedPlugin | null
+  busy: string | null
+  onSelect: (plugin: ManagedPlugin) => void
+  onToggle: (plugin: ManagedPlugin, enabled: boolean) => void
+  onReorder: (names: string[]) => void
+  onRefresh: () => void
+  onBrowse: () => void
+  onOpenPath: (path: string) => void
+  onOpenRepository: (url: string) => void
+  onUninstall: (plugin: ManagedPlugin) => void
+}
+
+export function PluginsView({
+  profile,
+  selected,
+  busy,
+  onSelect,
+  onToggle,
+  onReorder,
+  onRefresh,
+  onBrowse,
+  onOpenPath,
+  onOpenRepository,
+  onUninstall,
+}: PluginsViewProps) {
+  const [filter, setFilter] = useState('')
+  const [dragged, setDragged] = useState<string | null>(null)
+
+  const active = profile.plugins.filter(plugin => plugin.enabled)
+  const inactive = profile.plugins.filter(plugin => !plugin.enabled)
+  const activeNames = active.map(plugin => plugin.packageName)
+  const visible = (plugin: ManagedPlugin) =>
+    !filter || `${plugin.displayName} ${plugin.packageName}`.toLowerCase().includes(filter.toLowerCase())
+
+  const move = (packageName: string, direction: -1 | 1) => {
+    const names = movePackage(activeNames, packageName, direction)
+    if (names) onReorder(names)
+  }
+
+  const dropAt = (targetName: string) => {
+    const names = dragged ? movePackageTo(activeNames, dragged, targetName) : null
+    setDragged(null)
+    if (names) onReorder(names)
+  }
+
+  return (
+    <div className="page plugins-page">
+      <PageHeading
+        eyebrow="WEB PROFILE"
+        title="插件加载顺序"
+        description="上方先加载，下方可覆盖前序配置。停用插件不会从本机删除。"
+        actions={(
+          <>
+            <button className="secondary-button" type="button" onClick={onRefresh}><RefreshCw size={17} />刷新</button>
+            <button className="secondary-button accent" type="button" onClick={onBrowse}><Download size={17} />获取插件</button>
+          </>
+        )}
+      />
+
+      <div className="stats-strip" aria-label="配置概况">
+        <div><strong>{profile.activeBundles.length}</strong><span>已激活</span></div>
+        <div><strong>{profile.disabledCount}</strong><span>已停用</span></div>
+        <div><strong>{profile.dependencyCount}</strong><span>第三方依赖</span></div>
+        <button type="button" onClick={() => onOpenPath(profile.profileDir)} title="在资源管理器中打开配置目录">
+          <Folder size={16} /><span className="path-clip">{profile.profileDir}</span><ExternalLink size={14} />
+        </button>
+      </div>
+
+      {!profile.initialized ? (
+        <EmptyProfile onBrowse={onBrowse} />
+      ) : (
+        <div className="plugin-layout">
+          <section className="plugin-list-panel" aria-label="插件列表">
+            <div className="list-toolbar">
+              <label className="search-field compact">
+                <Search size={16} />
+                <input value={filter} onChange={event => setFilter(event.target.value)} placeholder="筛选已安装插件" />
+                {filter && <button type="button" onClick={() => setFilter('')} aria-label="清除筛选"><X size={15} /></button>}
+              </label>
+              <span>{active.length} 个加载层</span>
+            </div>
+            <div className="column-headings" aria-hidden="true">
+              <span>优先级</span><span>插件</span><span>版本</span><span>状态</span><span />
+            </div>
+            <div className="plugin-rows">
+              {active.filter(visible).map((plugin, index) => (
+                <PluginRow
+                  key={plugin.packageName}
+                  plugin={plugin}
+                  selected={selected?.packageName === plugin.packageName}
+                  busy={busy === plugin.packageName}
+                  dragging={dragged === plugin.packageName}
+                  canMoveUp={index > 0}
+                  canMoveDown={index < active.length - 1}
+                  onSelect={() => onSelect(plugin)}
+                  onToggle={enabled => onToggle(plugin, enabled)}
+                  onMove={moveDirection => move(plugin.packageName, moveDirection)}
+                  onDragStart={() => setDragged(plugin.packageName)}
+                  onDrop={() => dropAt(plugin.packageName)}
+                />
+              ))}
+              {inactive.length > 0 && <div className="disabled-divider"><span>已停用</span><i /></div>}
+              {inactive.filter(visible).map(plugin => (
+                <PluginRow
+                  key={plugin.packageName}
+                  plugin={plugin}
+                  selected={selected?.packageName === plugin.packageName}
+                  busy={busy === plugin.packageName}
+                  dragging={false}
+                  canMoveUp={false}
+                  canMoveDown={false}
+                  onSelect={() => onSelect(plugin)}
+                  onToggle={enabled => onToggle(plugin, enabled)}
+                  onMove={() => undefined}
+                  onDragStart={() => undefined}
+                  onDrop={() => undefined}
+                />
+              ))}
+            </div>
+          </section>
+          <PluginDetails
+            plugin={selected}
+            onOpenRepository={onOpenRepository}
+            onUninstall={onUninstall}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function PluginRow({ plugin, selected, busy, dragging, canMoveUp, canMoveDown, onSelect, onToggle, onMove, onDragStart, onDrop }: {
+  plugin: ManagedPlugin
+  selected: boolean
+  busy: boolean
+  dragging: boolean
+  canMoveUp: boolean
+  canMoveDown: boolean
+  onSelect: () => void
+  onToggle: (enabled: boolean) => void
+  onMove: (direction: -1 | 1) => void
+  onDragStart: () => void
+  onDrop: () => void
+}) {
+  return (
+    <div
+      className={`plugin-row ${selected ? 'selected' : ''} ${plugin.enabled ? '' : 'disabled'} ${dragging ? 'dragging' : ''}`}
+      draggable={plugin.enabled}
+      onDragStart={event => {
+        event.dataTransfer.effectAllowed = 'move'
+        onDragStart()
+      }}
+      onDragOver={event => event.preventDefault()}
+      onDrop={event => { event.preventDefault(); onDrop() }}
+      onClick={onSelect}
+    >
+      <div className="priority-cell">
+        {plugin.enabled ? <><GripVertical size={15} /><strong>{String(plugin.order).padStart(2, '0')}</strong></> : <span>—</span>}
+      </div>
+      <div className="plugin-identity">
+        <div className={`plugin-glyph glyph-${plugin.packageName.length % 4}`}>{pluginInitial(plugin)}</div>
+        <div><strong>{plugin.displayName}</strong><span>{plugin.packageName}</span></div>
+      </div>
+      <span className="plugin-version">{plugin.version}</span>
+      <div className="state-cell">
+        {!plugin.compatible && <span className="compatibility-warning" title="未检测到 dsh.bundle 声明"><CircleAlert size={16} /></span>}
+        <label className={`switch ${plugin.locked ? 'locked' : ''}`} title={plugin.locked ? '核心组合层始终启用' : plugin.enabled ? '停用插件' : '启用插件'} onClick={event => event.stopPropagation()}>
+          <input
+            type="checkbox"
+            checked={plugin.enabled}
+            disabled={plugin.locked || busy || !plugin.compatible}
+            onChange={event => onToggle(event.target.checked)}
+            aria-label={`${plugin.enabled ? '停用' : '启用'} ${plugin.displayName}`}
+          />
+          <span>{busy && <LoaderCircle className="spin" size={11} />}</span>
+        </label>
+      </div>
+      <div className="row-actions" onClick={event => event.stopPropagation()}>
+        <button type="button" disabled={!canMoveUp} onClick={() => onMove(-1)} title="向上移动" aria-label={`向上移动 ${plugin.displayName}`}><ArrowUp size={15} /></button>
+        <button type="button" disabled={!canMoveDown} onClick={() => onMove(1)} title="向下移动" aria-label={`向下移动 ${plugin.displayName}`}><ArrowDown size={15} /></button>
+      </div>
+    </div>
+  )
+}
+
+function PluginDetails({ plugin, onOpenRepository, onUninstall }: {
+  plugin: ManagedPlugin | null
+  onOpenRepository: (url: string) => void
+  onUninstall: (plugin: ManagedPlugin) => void
+}) {
+  if (!plugin) return <aside className="plugin-details empty">选择一个插件查看详情</aside>
+  return (
+    <aside className="plugin-details">
+      <div className="detail-topline">
+        <div className={`plugin-glyph large glyph-${plugin.packageName.length % 4}`}>{pluginInitial(plugin)}</div>
+        <div className={`detail-state ${plugin.enabled ? 'active' : ''}`}><span />{plugin.enabled ? '已激活' : '已停用'}</div>
+      </div>
+      <h2>{plugin.displayName}</h2>
+      <p className="package-name">{plugin.packageName}</p>
+      <p className="plugin-description">{plugin.description}</p>
+      <dl>
+        <div><dt>加载优先级</dt><dd>{plugin.order ? `#${String(plugin.order).padStart(2, '0')}` : '不加载'}</dd></div>
+        <div><dt>版本</dt><dd>{plugin.version}</dd></div>
+        <div><dt>来源</dt><dd>{plugin.builtin ? 'DSH 内置' : 'Profile 依赖'}</dd></div>
+        <div><dt>兼容性</dt><dd className={plugin.compatible ? 'good' : 'warning'}>{plugin.compatible ? 'Bundle 已识别' : '未检测到 Bundle'}</dd></div>
+      </dl>
+      <div className="detail-note">
+        <SlidersHorizontal size={16} />
+        <p>{plugin.enabled ? '本层会按当前优先级参与下一次 DSH 启动。' : '插件文件仍保留在本机，可随时重新启用。'}</p>
+      </div>
+      <div className="detail-actions">
+        {plugin.repository && <button type="button" className="secondary-button full" onClick={() => onOpenRepository(plugin.repository!)}><Github size={16} />查看仓库<ExternalLink size={14} /></button>}
+        {!plugin.builtin && <button type="button" className="danger-button full" onClick={() => onUninstall(plugin)}><Trash2 size={16} />从此配置卸载</button>}
+      </div>
+    </aside>
+  )
+}
+
+function EmptyProfile({ onBrowse }: { onBrowse: () => void }) {
+  return (
+    <div className="empty-state">
+      <div className="empty-icon"><PackageCheck size={28} /></div>
+      <h2>Web 配置尚未初始化</h2>
+      <p>首次启动 DSH 或安装插件时，官方 CLI 会创建 profile。启动器随后会在这里显示真实的组合层。</p>
+      <button type="button" className="primary-command" onClick={onBrowse}><Sparkles size={17} />浏览插件</button>
+    </div>
+  )
+}

--- a/src/views/RuntimeView.tsx
+++ b/src/views/RuntimeView.tsx
@@ -1,0 +1,78 @@
+import { CircleCheck, CircleStop, ExternalLink, LoaderCircle, Play, Settings, SquareTerminal } from 'lucide-react'
+import { useEffect, useRef } from 'react'
+import { PageHeading } from '../components/PageHeading'
+import type { AppSettings, RuntimeOutput, RuntimeState } from '../types'
+
+/** 运行与日志页：进程状态、启动参数与实时输出。 */
+
+interface RuntimeViewProps {
+  runtime: RuntimeState
+  settings: AppSettings
+  logs: RuntimeOutput[]
+  busy: boolean
+  onToggleRuntime: () => void
+  onOpenHarness: () => void
+  onClearLogs: () => void
+  onOpenSettings: () => void
+}
+
+export function RuntimeView({
+  runtime,
+  settings,
+  logs,
+  busy,
+  onToggleRuntime,
+  onOpenHarness,
+  onClearLogs,
+  onOpenSettings,
+}: RuntimeViewProps) {
+  const logEnd = useRef<HTMLDivElement>(null)
+
+  // 新日志到达时保持视图贴在底部。
+  useEffect(() => {
+    logEnd.current?.scrollIntoView?.({ block: 'nearest' })
+  }, [logs])
+
+  return (
+    <div className="page runtime-page">
+      <PageHeading
+        eyebrow="LOCAL RUNTIME"
+        title="运行 DeepSeek Harness"
+        description="从当前工作目录启动 Web 界面，并在这里查看进程状态与实时输出。"
+        actions={<button type="button" className="secondary-button" onClick={onOpenSettings}><Settings size={16} />启动设置</button>}
+      />
+      <section className={`runtime-band ${runtime.running ? 'running' : ''}`}>
+        <div className="runtime-status-icon">{runtime.running ? <CircleCheck size={25} /> : <CircleStop size={25} />}</div>
+        <div className="runtime-copy"><span>{runtime.running ? 'DSH 正在运行' : 'DSH 当前已停止'}</span><strong>{runtime.running ? runtime.url ?? '正在等待 Web 地址…' : '准备从本地启动'}</strong></div>
+        <div className="runtime-metadata"><span>配置 <strong>{settings.profileName}</strong></span><span>{runtime.pid ? `PID ${runtime.pid}` : '无活动进程'}</span></div>
+        {runtime.url && <button type="button" className="secondary-button" onClick={onOpenHarness}>打开工作台<ExternalLink size={15} /></button>}
+        <button type="button" className={`primary-command ${runtime.running ? 'stop' : ''}`} onClick={onToggleRuntime} disabled={busy}>
+          {busy ? <LoaderCircle className="spin" size={17} /> : runtime.running ? <CircleStop size={17} /> : <Play size={17} fill="currentColor" />}
+          {runtime.running ? '停止' : '启动'}
+        </button>
+      </section>
+
+      <div className="launch-facts">
+        <div><span>启动命令</span><code>{settings.launchExecutable} {settings.launchArgs.join(' ')}</code></div>
+        <div><span>工作目录</span><code>{settings.workspace}</code></div>
+        <div><span>DSH_HOME</span><code>{settings.dshHome}</code></div>
+      </div>
+
+      <section className="log-panel">
+        <header><div><SquareTerminal size={17} /><strong>运行日志</strong><span>{logs.length} 条</span></div><button type="button" onClick={onClearLogs} disabled={logs.length === 0}>清空</button></header>
+        <div className="log-output" role="log" aria-live="polite">
+          {logs.length === 0 ? (
+            <div className="log-empty"><SquareTerminal size={22} /><span>启动 DSH 后，输出会显示在这里。</span></div>
+          ) : logs.map((log, index) => (
+            <div className={`log-line ${log.level}`} key={`${log.timestamp}-${index}`}>
+              <time>{new Date(log.timestamp).toLocaleTimeString('zh-CN', { hour12: false })}</time>
+              <span className="log-channel">{log.channel === 'plugin' ? 'PLUGIN' : 'DSH'}</span>
+              <pre>{log.text}</pre>
+            </div>
+          ))}
+          <div ref={logEnd} />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/tests/command.test.ts
+++ b/tests/command.test.ts
@@ -1,0 +1,68 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+import { describe, expect, it } from 'vitest'
+import { collectCommandOutput, type CommandProcess } from '../electron/command'
+
+/** 一个只实现 collectCommandOutput 所需接口的子进程替身。 */
+function fakeProcess() {
+  const emitter = new EventEmitter()
+  const stdout = new PassThrough()
+  const stderr = new PassThrough()
+  const child = {
+    stdout,
+    stderr,
+    once: (event: string, listener: (...args: any[]) => void) => emitter.once(event, listener),
+  } as unknown as CommandProcess
+  return { child, stdout, stderr, emitter }
+}
+
+describe('collectCommandOutput', () => {
+  it('merges stdout and stderr in arrival order and reports the exit code', async () => {
+    const { child, stdout, stderr, emitter } = fakeProcess()
+    const pending = collectCommandOutput(child)
+
+    stdout.write('hello ')
+    stderr.write('warning ')
+    stdout.write('world')
+    emitter.emit('exit', 0)
+
+    await expect(pending).resolves.toEqual({ exitCode: 0, output: 'hello warning world' })
+  })
+
+  it('forwards each chunk with its stream level', async () => {
+    const { child, stdout, stderr, emitter } = fakeProcess()
+    const seen: Array<[string, string]> = []
+    const pending = collectCommandOutput(child, { onOutput: (text, level) => seen.push([level, text]) })
+
+    stdout.write('out')
+    stderr.write('err')
+    emitter.emit('exit', 0)
+    await pending
+
+    expect(seen).toEqual([['info', 'out'], ['error', 'err']])
+  })
+
+  it('keeps only the tail of the output once the capture limit is reached', async () => {
+    const { child, stdout, emitter } = fakeProcess()
+    const pending = collectCommandOutput(child, { captureLimit: 5 })
+
+    stdout.write('abcdefgh')
+    emitter.emit('exit', 0)
+
+    await expect(pending).resolves.toEqual({ exitCode: 0, output: 'defgh' })
+  })
+
+  it('treats a null exit code as a failure', async () => {
+    const { child, emitter } = fakeProcess()
+    const pending = collectCommandOutput(child)
+    emitter.emit('exit', null)
+    await expect(pending).resolves.toMatchObject({ exitCode: 1 })
+  })
+
+  it('rejects when the process fails to start', async () => {
+    const { child, emitter } = fakeProcess()
+    const pending = collectCommandOutput(child)
+    emitter.emit('error', new Error('ENOENT'))
+    await expect(pending).rejects.toThrow('ENOENT')
+  })
+})

--- a/tests/discovery.test.ts
+++ b/tests/discovery.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildSearchQuery,
+  buildSearchUrl,
+  describeSearchFailure,
+  mapRepository,
+  type GitHubRepositoryItem,
+} from '../electron/discovery'
+
+const item: GitHubRepositoryItem = {
+  id: 42,
+  full_name: 'someone/dsh-example',
+  name: 'dsh-example',
+  owner: { login: 'someone' },
+  description: 'An example plugin',
+  html_url: 'https://github.com/someone/dsh-example',
+  stargazers_count: 12,
+  language: 'TypeScript',
+  updated_at: '2026-08-01T00:00:00Z',
+  topics: ['dsh-plugin'],
+  default_branch: 'main',
+}
+
+describe('buildSearchQuery', () => {
+  it('always scopes the search to the dsh-plugin topic', () => {
+    expect(buildSearchQuery('')).toBe('topic:dsh-plugin')
+    expect(buildSearchQuery('   ')).toBe('topic:dsh-plugin')
+  })
+
+  it('appends a name and description filter for a real query', () => {
+    expect(buildSearchQuery('memory')).toBe('topic:dsh-plugin memory in:name,description')
+  })
+
+  it('strips characters that could inject extra search qualifiers', () => {
+    expect(buildSearchQuery('user:evil org:target')).toBe('topic:dsh-plugin user evil org target in:name,description')
+  })
+
+  it('keeps CJK characters', () => {
+    expect(buildSearchQuery('记忆')).toBe('topic:dsh-plugin 记忆 in:name,description')
+  })
+
+  it('caps the query length', () => {
+    const query = buildSearchQuery('a'.repeat(200))
+    expect(query).toBe(`topic:dsh-plugin ${'a'.repeat(80)} in:name,description`)
+  })
+})
+
+describe('buildSearchUrl', () => {
+  it('carries the sort order and page size', () => {
+    const url = buildSearchUrl('memory', 'updated')
+    expect(url.origin + url.pathname).toBe('https://api.github.com/search/repositories')
+    expect(url.searchParams.get('sort')).toBe('updated')
+    expect(url.searchParams.get('order')).toBe('desc')
+    expect(url.searchParams.get('per_page')).toBe('30')
+    expect(url.searchParams.get('q')).toBe('topic:dsh-plugin memory in:name,description')
+  })
+})
+
+describe('mapRepository', () => {
+  it('maps a plugin repository', () => {
+    expect(mapRepository(item)).toEqual({
+      id: 42,
+      fullName: 'someone/dsh-example',
+      name: 'dsh-example',
+      owner: 'someone',
+      description: 'An example plugin',
+      url: 'https://github.com/someone/dsh-example',
+      stars: 12,
+      language: 'TypeScript',
+      updatedAt: '2026-08-01T00:00:00Z',
+      topics: ['dsh-plugin'],
+      defaultBranch: 'main',
+      kind: 'plugin',
+    })
+  })
+
+  it('marks the official repository as the DSH core', () => {
+    expect(mapRepository({ ...item, full_name: 'deepseek-ai/deepseek-harness' }).kind).toBe('dsh')
+  })
+
+  it('substitutes placeholders for missing fields', () => {
+    const mapped = mapRepository({ ...item, description: null, topics: undefined })
+    expect(mapped.description).toBe('此仓库没有提供说明。')
+    expect(mapped.topics).toEqual([])
+  })
+})
+
+describe('describeSearchFailure', () => {
+  it('explains a rate limit separately from other failures', () => {
+    expect(describeSearchFailure(403).message).toMatch(/额度/)
+    expect(describeSearchFailure(500).message).toMatch(/500/)
+  })
+})

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { errorText, formatRelativeTime, formatStars, pluginInitial } from '../src/lib/format'
+import type { ManagedPlugin } from '../src/types'
+
+const plugin = (displayName: string): ManagedPlugin => ({
+  packageName: '@scope/dsh-example',
+  displayName,
+  version: '1.0.0',
+  description: '',
+  enabled: true,
+  builtin: false,
+  locked: false,
+  compatible: true,
+  order: 1,
+})
+
+describe('formatStars', () => {
+  it('shows counts under a thousand verbatim', () => {
+    expect(formatStars(0)).toBe('0')
+    expect(formatStars(999)).toBe('999')
+  })
+
+  it('abbreviates thousands with one decimal', () => {
+    expect(formatStars(1000)).toBe('1.0k')
+    expect(formatStars(1234)).toBe('1.2k')
+    expect(formatStars(45678)).toBe('45.7k')
+  })
+})
+
+describe('formatRelativeTime', () => {
+  const now = Date.parse('2026-08-14T12:00:00Z')
+
+  it('never reports less than a minute', () => {
+    expect(formatRelativeTime('2026-08-14T11:59:59Z', now)).toBe('1 分钟前')
+  })
+
+  it('reports minutes below an hour', () => {
+    expect(formatRelativeTime('2026-08-14T11:15:00Z', now)).toBe('45 分钟前')
+  })
+
+  it('reports hours below a day', () => {
+    expect(formatRelativeTime('2026-08-14T02:00:00Z', now)).toBe('10 小时前')
+  })
+
+  it('reports days below a month', () => {
+    expect(formatRelativeTime('2026-08-04T12:00:00Z', now)).toBe('10 天前')
+  })
+
+  it('falls back to a calendar date beyond thirty days', () => {
+    expect(formatRelativeTime('2026-01-04T12:00:00Z', now)).not.toMatch(/前$/)
+  })
+})
+
+describe('pluginInitial', () => {
+  it('takes the first two characters in upper case', () => {
+    expect(pluginInitial(plugin('memory bank'))).toBe('ME')
+  })
+
+  it('ignores surrounding whitespace', () => {
+    expect(pluginInitial(plugin('  ab  '))).toBe('AB')
+  })
+
+  it('handles a single character name', () => {
+    expect(pluginInitial(plugin('x'))).toBe('X')
+  })
+})
+
+describe('errorText', () => {
+  it('uses the message of an Error', () => {
+    expect(errorText(new Error('boom'))).toBe('boom')
+  })
+
+  it('stringifies anything else', () => {
+    expect(errorText('plain string')).toBe('plain string')
+    expect(errorText(404)).toBe('404')
+    expect(errorText(null)).toBe('null')
+  })
+})

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -1,0 +1,65 @@
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { buildPluginCommandArgs } from '../electron/installer'
+import type { AppSettings } from '../src/types'
+
+const onDemand: AppSettings = {
+  dshHome: '/home/tester/.dsh',
+  profileName: 'web',
+  workspace: '/home/tester/Documents',
+  launchExecutable: 'npx',
+  launchArgs: ['--yes', '@deepseek-ai/dsh', 'web'],
+  openAfterLaunch: true,
+}
+
+describe('buildPluginCommandArgs', () => {
+  it('reuses the npx prefix up to and including the package specifier', () => {
+    expect(buildPluginCommandArgs(onDemand, 'npx', ['add', 'github:someone/plugin'])).toEqual([
+      '--yes', '@deepseek-ai/dsh',
+      'plugin', '--profile', 'web',
+      'add', 'github:someone/plugin',
+    ])
+  })
+
+  it('drops the launch subcommand that follows the package specifier', () => {
+    // launchArgs 末尾的 web 是启动 DSH 用的，插件命令不能带上它。
+    const headless: AppSettings = { ...onDemand, profileName: 'headless' }
+    expect(buildPluginCommandArgs(headless, 'npx', ['remove', 'some-plugin'])).toEqual([
+      '--yes', '@deepseek-ai/dsh',
+      'plugin', '--profile', 'headless',
+      'remove', 'some-plugin',
+    ])
+  })
+
+  it('calls a bound dsh executable directly without a package prefix', () => {
+    const bound: AppSettings = {
+      ...onDemand,
+      launchExecutable: '/opt/dsh/node_modules/.bin/dsh',
+      launchArgs: ['web'],
+    }
+    expect(buildPluginCommandArgs(bound, '/opt/dsh/node_modules/.bin/dsh', ['add', 'github:a/b'])).toEqual([
+      'plugin', '--profile', 'web',
+      'add', 'github:a/b',
+    ])
+  })
+
+  it('recognizes the dsh.cmd wrapper used on Windows', () => {
+    const executable = path.join('C:', 'runtime', 'node_modules', '.bin', 'dsh.cmd')
+    const bound: AppSettings = { ...onDemand, launchExecutable: executable, launchArgs: ['web'] }
+    expect(buildPluginCommandArgs(bound, executable, ['add', 'github:a/b'])[0]).toBe('plugin')
+  })
+
+  it('falls back to fetching the package when the executable is unrelated', () => {
+    const custom: AppSettings = { ...onDemand, launchExecutable: 'node', launchArgs: ['./server.js'] }
+    expect(buildPluginCommandArgs(custom, 'node', ['add', 'github:a/b'])).toEqual([
+      '--yes', '@deepseek-ai/dsh',
+      'plugin', '--profile', 'web',
+      'add', 'github:a/b',
+    ])
+  })
+
+  it('carries a custom profile name through', () => {
+    const headless: AppSettings = { ...onDemand, profileName: 'headless' }
+    expect(buildPluginCommandArgs(headless, 'npx', ['add', 'github:a/b'])).toContain('headless')
+  })
+})

--- a/tests/node-runtime.test.ts
+++ b/tests/node-runtime.test.ts
@@ -1,12 +1,46 @@
-import { describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
 import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
 import {
   NODE_RUNTIME_VERSION,
+  findManagedNodeRuntime,
+  findSystemNodeRuntime,
   nodeArchiveName,
   parseNodeArchiveChecksum,
   requiresNodeRuntime,
   resolveNodeExecutable,
 } from '../electron/node-runtime'
+
+/** 当前平台上 node / npm / npx 的可执行文件名。 */
+const EXECUTABLES = process.platform === 'win32'
+  ? ['node.exe', 'npm.cmd', 'npx.cmd']
+  : ['node', 'npm', 'npx']
+
+/**
+ * POSIX 的官方发行包把可执行文件放在 bin/ 下，Windows 的 zip 直接平铺在根目录。
+ * 测试要按各自平台的真实布局造目录，否则测不出东西。
+ */
+const DISTRIBUTION_BIN = process.platform === 'win32' ? '.' : 'bin'
+
+let temporaryDirectory = ''
+
+async function makeTemporaryDirectory(): Promise<string> {
+  temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), 'dsh-node-runtime-'))
+  return temporaryDirectory
+}
+
+async function createExecutables(directory: string): Promise<void> {
+  await mkdir(directory, { recursive: true })
+  for (const name of EXECUTABLES) {
+    await writeFile(path.join(directory, name), '', 'utf8')
+  }
+}
+
+afterEach(async () => {
+  if (temporaryDirectory) await rm(temporaryDirectory, { recursive: true, force: true })
+  temporaryDirectory = ''
+})
 
 describe('node runtime', () => {
   it('selects the official Windows archive for the current architecture', () => {
@@ -41,5 +75,82 @@ describe('node runtime', () => {
     expect(requiresNodeRuntime('npx.cmd', ['--yes', '@deepseek-ai/dsh', 'web'])).toBe(true)
     expect(requiresNodeRuntime(path.join('C:', 'runtime', 'dsh.cmd'), ['web'])).toBe(true)
     expect(requiresNodeRuntime('custom.exe', ['serve'])).toBe(false)
+  })
+})
+
+/**
+ * PATH 里的每一项本身就是 bin 目录，官方发行包的根目录在 POSIX 上还多一层 bin/。
+ * 这两种布局曾经混用同一套拼接逻辑，导致 findSystemNodeRuntime
+ * 在任何 POSIX 系统上都必然返回 null。
+ */
+describe('node runtime discovery', () => {
+  it('finds a system runtime in a directory listed on PATH', async () => {
+    const binDirectory = await makeTemporaryDirectory()
+    await createExecutables(binDirectory)
+
+    const found = findSystemNodeRuntime({
+      PATH: binDirectory,
+      // Windows 会优先看 Program Files\nodejs，指向不存在的位置以保证结果确定。
+      ProgramFiles: path.join(binDirectory, 'absent'),
+    })
+
+    expect(found).not.toBeNull()
+    expect(found?.managed).toBe(false)
+    expect(found?.node).toBe(path.join(binDirectory, EXECUTABLES[0]))
+    expect(found?.npm).toBe(path.join(binDirectory, EXECUTABLES[1]))
+    expect(found?.npx).toBe(path.join(binDirectory, EXECUTABLES[2]))
+  })
+
+  it('skips PATH entries that only have some of the executables', async () => {
+    const root = await makeTemporaryDirectory()
+    const partial = path.join(root, 'partial')
+    await mkdir(partial, { recursive: true })
+    await writeFile(path.join(partial, EXECUTABLES[0]), '', 'utf8')
+
+    expect(findSystemNodeRuntime({
+      PATH: partial,
+      ProgramFiles: path.join(root, 'absent'),
+    })).toBeNull()
+  })
+
+  it('returns null when no PATH entry has a runtime', async () => {
+    const root = await makeTemporaryDirectory()
+    expect(findSystemNodeRuntime({
+      PATH: path.join(root, 'nowhere'),
+      ProgramFiles: path.join(root, 'absent'),
+    })).toBeNull()
+  })
+
+  it('finds a managed runtime laid out as an extracted distribution', async () => {
+    const runtimeRoot = await makeTemporaryDirectory()
+    const distribution = path.join(runtimeRoot, `node-${NODE_RUNTIME_VERSION}-win-x64`)
+    await createExecutables(path.join(distribution, DISTRIBUTION_BIN))
+
+    const found = await findManagedNodeRuntime(runtimeRoot)
+
+    expect(found).not.toBeNull()
+    expect(found?.managed).toBe(true)
+    expect(found?.root).toBe(distribution)
+    expect(found?.npm).toBe(path.join(distribution, DISTRIBUTION_BIN, EXECUTABLES[1]))
+  })
+
+  it('prefers the newest managed distribution', async () => {
+    const runtimeRoot = await makeTemporaryDirectory()
+    for (const version of ['node-v20.0.0-win-x64', 'node-v24.19.0-win-x64']) {
+      await createExecutables(path.join(runtimeRoot, version, DISTRIBUTION_BIN))
+    }
+
+    const found = await findManagedNodeRuntime(runtimeRoot)
+
+    expect(found?.root).toBe(path.join(runtimeRoot, 'node-v24.19.0-win-x64'))
+  })
+
+  it('ignores an incomplete managed distribution', async () => {
+    const runtimeRoot = await makeTemporaryDirectory()
+    const distribution = path.join(runtimeRoot, 'node-v24.19.0-win-x64', DISTRIBUTION_BIN)
+    await mkdir(distribution, { recursive: true })
+    await writeFile(path.join(distribution, EXECUTABLES[0]), '', 'utf8')
+
+    expect(await findManagedNodeRuntime(runtimeRoot)).toBeNull()
   })
 })

--- a/tests/node-runtime.test.ts
+++ b/tests/node-runtime.test.ts
@@ -31,13 +31,15 @@ describe('node runtime', () => {
       managed: true,
     }
     expect(resolveNodeExecutable('npx.cmd', runtime)).toBe(runtime.npx)
-    expect(resolveNodeExecutable('C:\\old\\npm.cmd', runtime)).toBe(runtime.npm)
+    // path.join 而不是硬编码反斜杠：反斜杠在 POSIX 上不是分隔符，
+    // 硬编码会让这条断言只在 Windows 上成立。
+    expect(resolveNodeExecutable(path.join('C:', 'old', 'npm.cmd'), runtime)).toBe(runtime.npm)
     expect(resolveNodeExecutable('custom.exe', runtime)).toBe('custom.exe')
   })
 
   it('detects commands that need Node.js on PATH', () => {
     expect(requiresNodeRuntime('npx.cmd', ['--yes', '@deepseek-ai/dsh', 'web'])).toBe(true)
-    expect(requiresNodeRuntime('C:\\runtime\\dsh.cmd', ['web'])).toBe(true)
+    expect(requiresNodeRuntime(path.join('C:', 'runtime', 'dsh.cmd'), ['web'])).toBe(true)
     expect(requiresNodeRuntime('custom.exe', ['serve'])).toBe(false)
   })
 })

--- a/tests/profile-order.test.ts
+++ b/tests/profile-order.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { movePackage, movePackageTo, reorderProfilePlugins } from '../src/lib/profile-order'
+import type { ManagedPlugin, ProfileState } from '../src/types'
+
+function plugin(packageName: string, enabled: boolean, order: number | null): ManagedPlugin {
+  return {
+    packageName,
+    displayName: packageName,
+    version: '1.0.0',
+    description: '',
+    enabled,
+    builtin: false,
+    locked: false,
+    compatible: true,
+    order,
+  }
+}
+
+const profile: ProfileState = {
+  initialized: true,
+  profileDir: '/home/tester/.dsh/profiles/web',
+  manifestPath: '/home/tester/.dsh/profiles/web/package.json',
+  activeBundles: ['a', 'b', 'c'],
+  dependencyCount: 3,
+  disabledCount: 1,
+  plugins: [plugin('a', true, 1), plugin('b', true, 2), plugin('c', true, 3), plugin('z', false, null)],
+}
+
+describe('reorderProfilePlugins', () => {
+  it('renumbers the enabled plugins to match the new order', () => {
+    const next = reorderProfilePlugins(profile, ['c', 'a', 'b'])
+    expect(next.activeBundles).toEqual(['c', 'a', 'b'])
+    expect(next.plugins.filter(p => p.enabled).map(p => [p.packageName, p.order])).toEqual([
+      ['c', 1], ['a', 2], ['b', 3],
+    ])
+  })
+
+  it('keeps disabled plugins last and unnumbered', () => {
+    const next = reorderProfilePlugins(profile, ['c', 'a', 'b'])
+    expect(next.plugins.at(-1)).toMatchObject({ packageName: 'z', enabled: false, order: null })
+  })
+
+  it('does not mutate the input profile', () => {
+    reorderProfilePlugins(profile, ['c', 'a', 'b'])
+    expect(profile.activeBundles).toEqual(['a', 'b', 'c'])
+    expect(profile.plugins[0].order).toBe(1)
+  })
+})
+
+describe('movePackage', () => {
+  it('swaps with the previous entry', () => {
+    expect(movePackage(['a', 'b', 'c'], 'b', -1)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('swaps with the next entry', () => {
+    expect(movePackage(['a', 'b', 'c'], 'b', 1)).toEqual(['a', 'c', 'b'])
+  })
+
+  it('returns null at the boundaries', () => {
+    expect(movePackage(['a', 'b'], 'a', -1)).toBeNull()
+    expect(movePackage(['a', 'b'], 'b', 1)).toBeNull()
+  })
+
+  it('returns null for an unknown package', () => {
+    expect(movePackage(['a', 'b'], 'missing', 1)).toBeNull()
+  })
+
+  it('does not mutate the input array', () => {
+    const names = ['a', 'b', 'c']
+    movePackage(names, 'b', 1)
+    expect(names).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('movePackageTo', () => {
+  it('moves an entry forward to the target position', () => {
+    expect(movePackageTo(['a', 'b', 'c', 'd'], 'a', 'c')).toEqual(['b', 'c', 'a', 'd'])
+  })
+
+  it('moves an entry backward to the target position', () => {
+    expect(movePackageTo(['a', 'b', 'c', 'd'], 'd', 'b')).toEqual(['a', 'd', 'b', 'c'])
+  })
+
+  it('returns null when dropped on itself', () => {
+    expect(movePackageTo(['a', 'b'], 'a', 'a')).toBeNull()
+  })
+
+  it('returns null when either package is unknown', () => {
+    expect(movePackageTo(['a', 'b'], 'missing', 'a')).toBeNull()
+    expect(movePackageTo(['a', 'b'], 'a', 'missing')).toBeNull()
+  })
+
+  it('does not mutate the input array', () => {
+    const names = ['a', 'b', 'c']
+    movePackageTo(names, 'a', 'c')
+    expect(names).toEqual(['a', 'b', 'c'])
+  })
+})

--- a/tests/renderer-events.test.ts
+++ b/tests/renderer-events.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import type { RendererChannel } from '../electron/app-window'
+import { createRendererEvents, normalizeOutputText } from '../electron/renderer-events'
+
+function recordingChannel() {
+  const sent: Array<{ channel: string; payload: unknown }> = []
+  const channel: RendererChannel = { send: (name, payload) => sent.push({ channel: name, payload }) }
+  return { channel, sent }
+}
+
+describe('normalizeOutputText', () => {
+  it('converts CRLF and trims trailing whitespace', () => {
+    expect(normalizeOutputText('first\r\nsecond\r\n')).toBe('first\nsecond')
+  })
+
+  it('leaves interior whitespace alone', () => {
+    expect(normalizeOutputText('  indented line')).toBe('  indented line')
+  })
+})
+
+describe('createRendererEvents', () => {
+  it('stamps output with the source channel, level and timestamp', () => {
+    const { channel, sent } = recordingChannel()
+    const events = createRendererEvents(channel, () => '2026-08-14T00:00:00.000Z')
+
+    events.output('plugin', 'error', 'install failed\r\n')
+
+    expect(sent).toEqual([{
+      channel: 'runtime:output',
+      payload: {
+        channel: 'plugin',
+        level: 'error',
+        text: 'install failed',
+        timestamp: '2026-08-14T00:00:00.000Z',
+      },
+    }])
+  })
+
+  it('drops output that is empty once normalized', () => {
+    const { channel, sent } = recordingChannel()
+    const events = createRendererEvents(channel)
+
+    events.output('runtime', 'info', '   \r\n')
+    events.output('runtime', 'info', '')
+
+    expect(sent).toEqual([])
+  })
+
+  it('forwards runtime state and install progress unchanged', () => {
+    const { channel, sent } = recordingChannel()
+    const events = createRendererEvents(channel)
+    const state = { running: true, pid: 4321, startedAt: '2026-08-14T00:00:00.000Z', url: 'http://127.0.0.1:5173' }
+    const progress = {
+      repository: 'someone/plugin',
+      kind: 'plugin' as const,
+      phase: 'downloading' as const,
+      percent: 40,
+      message: '正在下载',
+    }
+
+    events.runtimeState(state)
+    events.installProgress(progress)
+
+    expect(sent).toEqual([
+      { channel: 'runtime:state-changed', payload: state },
+      { channel: 'plugins:install-progress', payload: progress },
+    ])
+  })
+})

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { extractLocalUrl, runtimeEnvironment } from '../electron/runtime'
+import type { AppSettings } from '../src/types'
+
+describe('extractLocalUrl', () => {
+  it('picks up a loopback address with a port', () => {
+    expect(extractLocalUrl('Server listening on http://127.0.0.1:5173')).toBe('http://127.0.0.1:5173')
+  })
+
+  it('accepts localhost and a path', () => {
+    expect(extractLocalUrl('open http://localhost:3000/workspace now')).toBe('http://localhost:3000/workspace')
+  })
+
+  it('accepts https and a bare host', () => {
+    expect(extractLocalUrl('ready at https://localhost')).toBe('https://localhost')
+  })
+
+  it('ignores addresses that are not local', () => {
+    expect(extractLocalUrl('docs at https://example.com/guide')).toBeNull()
+  })
+
+  it('returns null when there is no address at all', () => {
+    expect(extractLocalUrl('compiling…')).toBeNull()
+  })
+})
+
+describe('runtimeEnvironment', () => {
+  const settings = {
+    dshHome: '/home/tester/.dsh',
+    profileName: 'web',
+    workspace: '/home/tester/Documents',
+    launchExecutable: 'npx',
+    launchArgs: ['web'],
+    openAfterLaunch: true,
+  } satisfies AppSettings
+
+  it('injects DSH_HOME and disables colored output', () => {
+    const environment = runtimeEnvironment(settings, { PATH: '/usr/bin' })
+    expect(environment.DSH_HOME).toBe('/home/tester/.dsh')
+    expect(environment.FORCE_COLOR).toBe('0')
+    expect(environment.PATH).toBe('/usr/bin')
+  })
+
+  it('overrides an inherited DSH_HOME', () => {
+    expect(runtimeEnvironment(settings, { DSH_HOME: '/stale' }).DSH_HOME).toBe('/home/tester/.dsh')
+  })
+})

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,0 +1,158 @@
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  adoptDetectedDsh,
+  defaultSettings,
+  mergeStoredSettings,
+  usesOnDemandDsh,
+  validateSettings,
+} from '../electron/settings'
+import type { AppSettings } from '../src/types'
+
+const baseSettings: AppSettings = {
+  dshHome: '/home/tester/.dsh',
+  profileName: 'web',
+  workspace: '/home/tester/Documents',
+  launchExecutable: 'npx',
+  launchArgs: ['--yes', '@deepseek-ai/dsh', 'web'],
+  openAfterLaunch: true,
+}
+
+describe('defaultSettings', () => {
+  it('prefers DSH_HOME from the environment', () => {
+    const settings = defaultSettings({
+      dshHomeFromEnvironment: '/custom/dsh',
+      homeDirectory: '/home/tester',
+      documentsDirectory: '/home/tester/Documents',
+      platform: 'linux',
+    })
+    expect(settings.dshHome).toBe('/custom/dsh')
+  })
+
+  it('falls back to a .dsh directory under home', () => {
+    const settings = defaultSettings({
+      homeDirectory: '/home/tester',
+      documentsDirectory: '/home/tester/Documents',
+      platform: 'linux',
+    })
+    expect(settings.dshHome).toBe('/home/tester/.dsh')
+    expect(settings.launchExecutable).toBe('npx')
+  })
+
+  it('uses the detected system npx when available', () => {
+    const settings = defaultSettings({
+      homeDirectory: '/home/tester',
+      documentsDirectory: '/home/tester/Documents',
+      systemNpx: 'C:\\Program Files\\nodejs\\npx.cmd',
+      platform: 'win32',
+    })
+    expect(settings.launchExecutable).toBe('C:\\Program Files\\nodejs\\npx.cmd')
+  })
+
+  it('uses the platform default executable name without a detected runtime', () => {
+    expect(defaultSettings({
+      homeDirectory: 'C:\\Users\\tester',
+      documentsDirectory: 'C:\\Users\\tester\\Documents',
+      platform: 'win32',
+    }).launchExecutable).toBe('npx.cmd')
+  })
+})
+
+describe('validateSettings', () => {
+  it('trims the executable and keeps the remaining fields', () => {
+    const validated = validateSettings({ ...baseSettings, launchExecutable: '  npx  ' })
+    expect(validated.launchExecutable).toBe('npx')
+    expect(validated.launchArgs).toEqual(baseSettings.launchArgs)
+  })
+
+  it('rejects a profile name with path separators', () => {
+    expect(() => validateSettings({ ...baseSettings, profileName: '../escape' })).toThrow(/配置名称/)
+  })
+
+  it('rejects relative directories', () => {
+    expect(() => validateSettings({ ...baseSettings, dshHome: 'relative/path' })).toThrow(/完整路径/)
+    expect(() => validateSettings({ ...baseSettings, workspace: './work' })).toThrow(/完整路径/)
+  })
+
+  it('rejects an empty launch command', () => {
+    expect(() => validateSettings({ ...baseSettings, launchExecutable: '   ' })).toThrow(/启动命令/)
+  })
+
+  it('rejects launch arguments that are not all strings', () => {
+    expect(() => validateSettings({ ...baseSettings, launchArgs: ['web', 42 as unknown as string] })).toThrow(/启动参数/)
+  })
+
+  it('coerces openAfterLaunch to a boolean', () => {
+    expect(validateSettings({ ...baseSettings, openAfterLaunch: 1 as unknown as boolean }).openAfterLaunch).toBe(true)
+  })
+})
+
+describe('mergeStoredSettings', () => {
+  it('returns the defaults when nothing is stored', () => {
+    expect(mergeStoredSettings(baseSettings, null)).toEqual(baseSettings)
+  })
+
+  it('lets stored values win over the defaults', () => {
+    const merged = mergeStoredSettings(baseSettings, { profileName: 'headless' })
+    expect(merged.profileName).toBe('headless')
+    expect(merged.dshHome).toBe(baseSettings.dshHome)
+  })
+
+  it('drops non-string launch arguments instead of failing', () => {
+    const merged = mergeStoredSettings(baseSettings, {
+      launchArgs: ['web', 7 as unknown as string, 'extra'],
+    })
+    expect(merged.launchArgs).toEqual(['web', 'extra'])
+  })
+
+  it('falls back to the default arguments when the stored value is not an array', () => {
+    const merged = mergeStoredSettings(baseSettings, { launchArgs: 'web' as unknown as string[] })
+    expect(merged.launchArgs).toEqual(baseSettings.launchArgs)
+  })
+})
+
+describe('usesOnDemandDsh', () => {
+  it('recognizes an npx-based launch configuration', () => {
+    expect(usesOnDemandDsh(baseSettings)).toBe(true)
+    expect(usesOnDemandDsh({
+      ...baseSettings,
+      launchExecutable: path.join('C:', 'nodejs', 'npx.cmd'),
+    })).toBe(true)
+  })
+
+  it('does not match a configuration bound to a local dsh executable', () => {
+    expect(usesOnDemandDsh({
+      ...baseSettings,
+      launchExecutable: '/opt/dsh/node_modules/.bin/dsh',
+      launchArgs: ['web'],
+    })).toBe(false)
+  })
+
+  it('does not match npx invoked for some other package', () => {
+    expect(usesOnDemandDsh({ ...baseSettings, launchArgs: ['--yes', 'other-package'] })).toBe(false)
+  })
+})
+
+describe('adoptDetectedDsh', () => {
+  const detected = { installed: true, version: '1.2.3', executable: '/opt/dsh/dsh', source: 'system' as const }
+
+  it('switches an on-demand configuration to the detected executable', () => {
+    const next = adoptDetectedDsh(baseSettings, detected)
+    expect(next.launchExecutable).toBe('/opt/dsh/dsh')
+    expect(next.launchArgs).toEqual(['web'])
+  })
+
+  it('leaves an already bound configuration untouched', () => {
+    const bound = { ...baseSettings, launchExecutable: '/existing/dsh', launchArgs: ['web'] }
+    expect(adoptDetectedDsh(bound, detected)).toBe(bound)
+  })
+
+  it('leaves the configuration untouched when nothing was detected', () => {
+    expect(adoptDetectedDsh(baseSettings, {
+      installed: false,
+      version: null,
+      executable: null,
+      source: null,
+    })).toBe(baseSettings)
+  })
+})


### PR DESCRIPTION
## 背景

两个文件承担了几乎全部逻辑：

| 文件 | 行数 | 混在一起的职责 |
| --- | --- | --- |
| `electron/main.ts` | 649 | 设置持久化、进程生命周期、安装编排、GitHub 检索、窗口管理、消息推送、IPC 注册、应用生命周期 |
| `src/App.tsx` | 1139 | 14 个 `useState` + 8 个异步动作 + 13 个展示组件 |

结果是任何改动都要动这两个文件，且主进程**一行都无法单测** —— `main.ts` 顶层 `import electron` 并依赖 7 个模块级 `let`。

> [!IMPORTANT]
> **结构调整部分不改变任何外部行为。**唯一的例外是最后一个 commit（`3c12cf8`）—— 它修复了一个在重构过程中发现的、会让 Linux/macOS 完全不可用的缺陷，详见下方「顺带修复的两个既有缺陷」。

---

## 主进程：8 → 16 个模块，`main.ts` 降至 138 行

`main.ts` 现在只剩装配根：声明谁依赖谁，不含业务逻辑。

| 新模块 | 职责 | 行数 |
| --- | --- | --- |
| `settings.ts` | 默认值、校验、持久化、缓存 | 118 |
| `runtime.ts` | DSH 进程启停、输出转发、状态广播 | 136 |
| `installer.ts` | 插件与本体安装编排、进度推送 | 308 |
| `discovery.ts` | GitHub 插件检索 | 90 |
| `ipc.ts` | 全部 IPC 注册（唯一入口） | 114 |
| `app-window.ts` | 窗口创建、尺寸模式、渲染层通道 | 89 |
| `renderer-events.ts` | 推送给渲染层的三类事件 | 47 |
| `command.ts` | 子进程执行与输出收集 | 65 |

原有的 `dsh-install.ts` / `node-runtime.ts` / `profile.ts` / `plugin-install.ts` / `process.ts` / `credentials.ts` 边界本来就清晰，保持不动。

## 渲染层：5 → 24 个文件，`App.tsx` 降至 190 行

`App.tsx` 现在只做三件事：提供主进程 API、组装状态与视图、挂载对话框。

```
src/
├── api/client.ts              # 主进程 API 的 context 注入
├── constants.ts               # 主进程与渲染层的共享常量
├── hooks/
│   ├── use-launcher-store.ts  # 领域状态与全部写操作
│   ├── use-async-action.ts    # 忙碌标记 + 提示的统一处理
│   ├── use-navigation.ts      # surface / view 与窗口尺寸联动
│   └── use-toast.ts
├── lib/
│   ├── format.ts              # 格式化纯函数
│   └── profile-order.ts       # 加载顺序重排纯函数
├── components/                # LauncherHome、AppHeader、SideNavigation、
│   └── dialogs/               #   PageHeading、Toast、三个对话框
└── views/                     # PluginsView、DiscoverView、RuntimeView
```

---

## 消除的重复

| 重复内容 | 原本 | 现在 |
| --- | --- | --- |
| 「窗口是否存活」守卫 | `emitState` / `emitOutput` / `emitInstallProgress` **3 处**各写一遍 | `createRendererChannel` 1 处 |
| 「spawn → 挂 stdout/stderr → 累积输出 → 等退出码」 | `runPluginCommand` 与 `installManagedDsh` **2 处**各约 25 行 | `runCommand` 1 处 |
| 「`setBusy` → `try` → `showToast` → `finally setBusy(null)`」 | **6 个动作**各写一遍 | `useAsyncAction` 1 处 |
| `DSH_REPOSITORY` | `src/App.tsx:56` 与 `electron/dsh-install.ts:5` **各定义一次** | `src/constants.ts` |
| IPC 通道名字面量 | `main.ts` 与 `preload.ts` **各写一遍**，改名只改一边不会报错 | `IPC` / `IPC_EVENTS` 常量表，两侧共用 |
| `EMPTY_DSH_INSTALLATION` | 第 55 行定义，第 825 行又内联重写一次 | 共享常量 |

## 消除的模块级可变状态

主进程原有 7 个 `module-level let`（`mainWindow`、`runtimeProcess`、`runtimeStartedAt`、`runtimeUrl`、`settingsCache`、`quitAfterRuntimeStops`、`activeInstallation`）。

除 `mainWindow` 与 `quitAfterRuntimeStops`（确实属于应用生命周期，留在 `main.ts`）外，其余全部收进各自工厂函数的闭包，依赖改为构造时注入。副作用是这些模块不再直接依赖 `electron`，可以脱离 Electron 环境单测。

---

## 可测试性

主进程此前 **0 行可测**。现新增 8 个测试文件：

| 文件 | 覆盖 |
| --- | --- |
| `settings.test.ts` | 默认值推导、校验、存储合并、按需拉取识别、检测后自动绑定 |
| `command.test.ts` | 输出合并顺序、分级转发、截断上限、异常退出码、启动失败 |
| `discovery.test.ts` | 检索式构造（含**搜索限定符注入的剔除**）、URL 参数、结果映射、错误分类 |
| `installer.test.ts` | 三种启动配置下的 CLI 参数拼接 |
| `renderer-events.test.ts` | CRLF 归一化、空输出丢弃、三类事件的负载成形 |
| `runtime.test.ts` | 本地地址识别、环境变量注入 |
| `format.test.ts` | 星标缩写、相对时间、首字母、错误文案 |
| `profile-order.test.ts` | 重排编号、上下移动、拖放插入、不可变性 |

**测试总数 27 → 111。**

---

## 顺带修复的两个既有缺陷

两个都不是重构引入的，而是在 Linux 上跑测试才暴露出来的既有问题。

### 1. `runtimePaths` 让 POSIX 上的系统 Node.js 检测必然失败 ⚠️

`runtimePaths` 被两处调用方以**两种不同的目录布局**复用，却只有一套拼接逻辑，而且这套逻辑把两种布局混在了一起：

```ts
node: path.join(root, 'node'),          // 按「PATH 中的 bin 目录」
npm:  path.join(root, 'bin', 'npm'),    // 按「发行包解压根目录」
npx:  path.join(root, 'bin', 'npx'),    // 同上
```

`findSystemNodeRuntime` 遍历的是 `PATH` 条目，而 PATH 条目本身就是 bin 目录，于是它去找 `/usr/bin/bin/npm`。`isCompleteRuntime` 要求三个可执行文件同时存在，**因此该函数在任何 POSIX 系统上都必然返回 `null`**。

后果链条：检测不到系统 Node → 回落到下载便携运行时 → 那条路径对非 win32 直接抛出「自动准备运行环境目前仅支持 Windows」。**Linux/macOS 用户即使已正确安装 Node.js，启动器也会拒绝启动 DSH。** README 声称开发调试可跨平台，实际被这个 bug 挡死。

Windows 上不显形，因为官方 zip 与 PATH 目录恰好都是三个文件平铺在根目录，两种布局重合。

修法是让 `runtimePaths` 显式接收布局参数（`bin-directory` / `distribution-root`），而不是靠一套拼接去猜。

在 Linux 实机上验证：修复前 `findSystemNodeRuntime()` 返回 `null`，修复后正确返回 `bin/node`、`bin/npm`、`bin/npx`。

新增 6 个发现逻辑的测试（PATH 命中、部分文件、全部缺失、发行包布局、多版本择新、发行包不完整），按各自平台的真实布局造目录。**已验证这些测试确实能拦住该缺陷：还原实现后 3 个失败，恢复后全过。**

### 2. `node-runtime.test.ts` 中只在 Windows 成立的路径断言

两条断言硬编码了 Windows 反斜杠：

```ts
expect(resolveNodeExecutable('C:\\old\\npm.cmd', runtime)).toBe(runtime.npm)
expect(requiresNodeRuntime('C:\\runtime\\dsh.cmd', ['web'])).toBe(true)
```

`path.basename` 在 POSIX 上不把反斜杠当分隔符，这两条在 Linux 上必然失败。已改用 `path.join`。

> 这一条也在 CI 那个 PR 里 —— 两边改动逐字相同，合并时 git 会自动解决，不会冲突。

---

## `formatStars` 里一个疑似笔误，我**保留了原行为**

原代码：

```ts
return `${(value / 1000).toFixed(value >= 10000 ? 1 : 1)}k`
```

三元的两个分支都是 `1`，看起来本意是 `value >= 10000 ? 0 : 1`（即上万时不显示小数）。因为意图不确定，我只把它简化成等价的 `.toFixed(1)`，**输出完全不变**。要改成 `12k` 而不是 `12.3k` 的话，告诉我一声。

---

## 验证

在 Node 20 + Linux 上实际执行：

- ✅ `tsc --noEmit` 通过
- ✅ 111 个测试全过（4 个 Windows 专属用例按既有约定跳过）
- ✅ `npm run build` 三个产物均正常产出（渲染层 202 kB、主进程 219 kB、preload 2.32 kB）
- ✅ IPC 面逐条比对：**20 个 handler 一个不少**，preload 暴露的 **23 个方法数量与名称均未变化**
- ✅ 54 个源文件的相对导入全部可解析

### 我没能验证的部分

**没有在 Windows 上实际运行过启动器。** 我这边是 Linux 集群，跑不了 Electron GUI。展示组件是逐段搬移的、JSX 未作改写，但下面几处涉及时序，建议合并前在 Windows 上手动过一遍：

1. **启动 / 停止 DSH**，确认日志面板正常滚动、URL 被识别后自动打开浏览器
2. **安装一个插件**，确认进度条的五个阶段与百分比表现如常
3. **首次部署流程**（未安装 DSH 时点主按钮）
4. **拖拽调整加载顺序**，确认失败时会回滚
5. **保存设置 / 保存 API Key**，确认对话框正常关闭

其中第 1、3 项尤其值得看 —— `runtimePaths` 的改动虽然只影响 POSIX 分支（Windows 分支一字未改），但它位于 Node.js 检测这条关键路径上。

> 另有一处**极小的时序差异**：原先「保存设置」是先关对话框再刷新 Profile，现在改为全部完成后再关。表现上是对话框多显示约 100ms 的加载态，我认为这样更合理，但如果你希望保持原样可以调回去。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
