### PR TITLE
fix: 修正 POSIX 上系统 Node.js 检测必然失败的路径拼接

### DIFF
--- a/electron/node-runtime.ts
+++ b/electron/node-runtime.ts
@@ -31,7 +31,18 @@ type ProgressListener = (progress: NodeRuntimeProgress) => void
 let installationPromise: Promise<NodeRuntime> | null = null
 let pnpmInstallationPromise: Promise<PnpmRuntime> | null = null
 
-function runtimePaths(root: string, managed: boolean): NodeRuntime {
+/**
+ * 可执行文件相对于 root 的两种摆放方式。
+ *
+ * - `bin-directory`：root 本身就是存放可执行文件的目录，例如 PATH 里的 `/usr/bin`。
+ * - `distribution-root`：root 是官方发行包解压后的根目录，例如 `node-v24.19.0-linux-x64/`。
+ *
+ * Windows 上两者一致（zip 与 PATH 目录都是三个文件平铺）；
+ * POSIX 上发行包把可执行文件放在 `bin/` 子目录里，差一层。
+ */
+type RuntimeLayout = 'bin-directory' | 'distribution-root'
+
+function runtimePaths(root: string, managed: boolean, layout: RuntimeLayout): NodeRuntime {
   if (process.platform === 'win32') {
     return {
       root,
@@ -41,11 +52,12 @@ function runtimePaths(root: string, managed: boolean): NodeRuntime {
       managed,
     }
   }
+  const binary = layout === 'distribution-root' ? path.join(root, 'bin') : root
   return {
     root,
-    node: path.join(root, 'node'),
-    npm: path.join(root, 'bin', 'npm'),
-    npx: path.join(root, 'bin', 'npx'),
+    node: path.join(binary, 'node'),
+    npm: path.join(binary, 'npm'),
+    npx: path.join(binary, 'npx'),
     managed,
   }
 }
@@ -83,7 +95,8 @@ export function findSystemNodeRuntime(environment: NodeJS.ProcessEnv = process.e
     entries.unshift(path.join(environment.ProgramFiles ?? 'C:\\Program Files', 'nodejs'))
   }
   for (const entry of entries) {
-    const runtime = runtimePaths(entry.replace(/^"|"$/g, ''), false)
+    // PATH 里的每一项本身就是可执行文件所在的目录。
+    const runtime = runtimePaths(entry.replace(/^"|"$/g, ''), false, 'bin-directory')
     if (isCompleteRuntime(runtime)) return runtime
   }
   return null
@@ -110,7 +123,7 @@ export async function findManagedNodeRuntime(runtimeRoot: string): Promise<NodeR
     .map(entry => entry.name)
     .sort((a, b) => b.localeCompare(a, 'en'))
   for (const directory of directories) {
-    const runtime = runtimePaths(path.join(runtimeRoot, directory), true)
+    const runtime = runtimePaths(path.join(runtimeRoot, directory), true, 'distribution-root')
     if (isCompleteRuntime(runtime)) return runtime
   }
   return null
@@ -166,7 +179,7 @@ async function installManagedNodeRuntime(runtimeRoot: string, onProgress?: Progr
   const archiveName = nodeArchiveName()
   const extractedName = archiveName.slice(0, -4)
   const finalRoot = path.join(runtimeRoot, extractedName)
-  const existing = runtimePaths(finalRoot, true)
+  const existing = runtimePaths(finalRoot, true, 'distribution-root')
   if (isCompleteRuntime(existing)) return existing
 
   const nonce = `${process.pid}-${Date.now()}`
@@ -219,11 +232,11 @@ async function installManagedNodeRuntime(runtimeRoot: string, onProgress?: Progr
     if (exitCode !== 0) throw new Error(`解压 Node.js 运行环境失败：${extractionError.trim() || `代码 ${exitCode}`}`)
 
     const stagedRoot = path.join(stagingRoot, extractedName)
-    const stagedRuntime = runtimePaths(stagedRoot, true)
+    const stagedRuntime = runtimePaths(stagedRoot, true, 'distribution-root')
     if (!isCompleteRuntime(stagedRuntime)) throw new Error('Node.js 运行环境解压后文件不完整。')
     await rm(finalRoot, { recursive: true, force: true })
     await rename(stagedRoot, finalRoot)
-    const installed = runtimePaths(finalRoot, true)
+    const installed = runtimePaths(finalRoot, true, 'distribution-root')
     await rm(archivePath, { force: true })
     onProgress?.({ percent: 100, message: `Node.js ${NODE_RUNTIME_VERSION} 已就绪` })
     return installed

--- a/tests/node-runtime.test.ts
+++ b/tests/node-runtime.test.ts
@@ -1,14 +1,48 @@
-import { describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
 import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
 import {
   NODE_RUNTIME_VERSION,
   PNPM_VERSION,
+  findManagedNodeRuntime,
+  findSystemNodeRuntime,
   nodeArchiveName,
   parseNodeArchiveChecksum,
   pnpmExecutable,
   requiresNodeRuntime,
   resolveNodeExecutable,
 } from '../electron/node-runtime'
+
+/** 当前平台上 node / npm / npx 的可执行文件名。 */
+const EXECUTABLES = process.platform === 'win32'
+  ? ['node.exe', 'npm.cmd', 'npx.cmd']
+  : ['node', 'npm', 'npx']
+
+/**
+ * POSIX 的官方发行包把可执行文件放在 bin/ 下，Windows 的 zip 直接平铺在根目录。
+ * 测试要按各自平台的真实布局造目录，否则测不出东西。
+ */
+const DISTRIBUTION_BIN = process.platform === 'win32' ? '.' : 'bin'
+
+let temporaryDirectory = ''
+
+async function makeTemporaryDirectory(): Promise<string> {
+  temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), 'dsh-node-runtime-'))
+  return temporaryDirectory
+}
+
+async function createExecutables(directory: string): Promise<void> {
+  await mkdir(directory, { recursive: true })
+  for (const name of EXECUTABLES) {
+    await writeFile(path.join(directory, name), '', 'utf8')
+  }
+}
+
+afterEach(async () => {
+  if (temporaryDirectory) await rm(temporaryDirectory, { recursive: true, force: true })
+  temporaryDirectory = ''
+})
 
 describe('node runtime', () => {
   it('selects the official Windows archive for the current architecture', () => {
@@ -55,5 +89,82 @@ describe('node runtime', () => {
     expect(requiresNodeRuntime('npx.cmd', ['--yes', '@deepseek-ai/dsh', 'web'])).toBe(true)
     expect(requiresNodeRuntime(path.join('C:', 'runtime', 'dsh.cmd'), ['web'])).toBe(true)
     expect(requiresNodeRuntime('custom.exe', ['serve'])).toBe(false)
+  })
+})
+
+/**
+ * PATH 里的每一项本身就是 bin 目录，官方发行包的根目录在 POSIX 上还多一层 bin/。
+ * 这两种布局曾经混用同一套拼接逻辑，导致 findSystemNodeRuntime
+ * 在任何 POSIX 系统上都必然返回 null。
+ */
+describe('node runtime discovery', () => {
+  it('finds a system runtime in a directory listed on PATH', async () => {
+    const binDirectory = await makeTemporaryDirectory()
+    await createExecutables(binDirectory)
+
+    const found = findSystemNodeRuntime({
+      PATH: binDirectory,
+      // Windows 会优先看 Program Files\nodejs，指向不存在的位置以保证结果确定。
+      ProgramFiles: path.join(binDirectory, 'absent'),
+    })
+
+    expect(found).not.toBeNull()
+    expect(found?.managed).toBe(false)
+    expect(found?.node).toBe(path.join(binDirectory, EXECUTABLES[0]))
+    expect(found?.npm).toBe(path.join(binDirectory, EXECUTABLES[1]))
+    expect(found?.npx).toBe(path.join(binDirectory, EXECUTABLES[2]))
+  })
+
+  it('skips PATH entries that only have some of the executables', async () => {
+    const root = await makeTemporaryDirectory()
+    const partial = path.join(root, 'partial')
+    await mkdir(partial, { recursive: true })
+    await writeFile(path.join(partial, EXECUTABLES[0]), '', 'utf8')
+
+    expect(findSystemNodeRuntime({
+      PATH: partial,
+      ProgramFiles: path.join(root, 'absent'),
+    })).toBeNull()
+  })
+
+  it('returns null when no PATH entry has a runtime', async () => {
+    const root = await makeTemporaryDirectory()
+    expect(findSystemNodeRuntime({
+      PATH: path.join(root, 'nowhere'),
+      ProgramFiles: path.join(root, 'absent'),
+    })).toBeNull()
+  })
+
+  it('finds a managed runtime laid out as an extracted distribution', async () => {
+    const runtimeRoot = await makeTemporaryDirectory()
+    const distribution = path.join(runtimeRoot, `node-${NODE_RUNTIME_VERSION}-win-x64`)
+    await createExecutables(path.join(distribution, DISTRIBUTION_BIN))
+
+    const found = await findManagedNodeRuntime(runtimeRoot)
+
+    expect(found).not.toBeNull()
+    expect(found?.managed).toBe(true)
+    expect(found?.root).toBe(distribution)
+    expect(found?.npm).toBe(path.join(distribution, DISTRIBUTION_BIN, EXECUTABLES[1]))
+  })
+
+  it('prefers the newest managed distribution', async () => {
+    const runtimeRoot = await makeTemporaryDirectory()
+    for (const version of ['node-v20.0.0-win-x64', 'node-v24.19.0-win-x64']) {
+      await createExecutables(path.join(runtimeRoot, version, DISTRIBUTION_BIN))
+    }
+
+    const found = await findManagedNodeRuntime(runtimeRoot)
+
+    expect(found?.root).toBe(path.join(runtimeRoot, 'node-v24.19.0-win-x64'))
+  })
+
+  it('ignores an incomplete managed distribution', async () => {
+    const runtimeRoot = await makeTemporaryDirectory()
+    const distribution = path.join(runtimeRoot, 'node-v24.19.0-win-x64', DISTRIBUTION_BIN)
+    await mkdir(distribution, { recursive: true })
+    await writeFile(path.join(distribution, EXECUTABLES[0]), '', 'utf8')
+
+    expect(await findManagedNodeRuntime(runtimeRoot)).toBeNull()
   })
 })


### PR DESCRIPTION
## 问题

`electron/node-runtime.ts` 的 `runtimePaths` 被**两处调用方以两种不同的目录布局**复用，却只有一套拼接逻辑，而且这套逻辑把两种布局混在了一起：

```ts
node: path.join(root, 'node'),          // 按「PATH 中的 bin 目录」
npm:  path.join(root, 'bin', 'npm'),    // 按「发行包解压根目录」
npx:  path.join(root, 'bin', 'npx'),    // 同上
```

`findSystemNodeRuntime` 遍历的是 `PATH` 条目，而 PATH 条目本身**就是** bin 目录，于是它去找 `/usr/bin/bin/npm`。`isCompleteRuntime` 要求三个可执行文件同时存在，**因此该函数在任何 POSIX 系统上都必然返回 `null`**。

Linux 实机验证（修复前）：

```
node 实际位置 : /cvmfs/.../nodejs/20.16.0/bin/node
npm  实际存在 : true
代码期望的 npm: /cvmfs/.../nodejs/20.16.0/bin/bin/npm → 存在? false
findSystemNodeRuntime() = null
```

### 影响

检测不到系统 Node → 回落到下载便携运行时 → 那条路径对非 win32 直接抛出「自动准备运行环境目前仅支持 Windows」。

**Linux / macOS 用户即使已正确安装 Node.js，启动器也会拒绝启动 DSH。** README 的「从源码运行」章节声称开发调试可跨平台，实际被这个缺陷挡死。

Windows 上不显形 —— 官方 zip 与 PATH 目录恰好都是三个文件平铺在根目录，两种布局重合。

## 修法

让 `runtimePaths` 显式接收布局参数，而不是靠一套拼接去猜两种情况：

| 布局 | 含义 | 调用方 |
| --- | --- | --- |
| `bin-directory` | root 就是可执行文件所在目录 | `findSystemNodeRuntime`（遍历 PATH） |
| `distribution-root` | root 是发行包解压根目录，POSIX 下多一层 `bin/` | `findManagedNodeRuntime`、`installManagedNodeRuntime` |

**Windows 分支一字未改。**

## 测试

新增 6 个发现逻辑的测试：PATH 命中、只有部分可执行文件、全部缺失、发行包布局、多版本择新、发行包不完整。测试按各自平台的真实布局造临时目录，两个平台验证同一套语义。

> **已验证这些测试确实能拦住该缺陷**：把实现还原成旧版本后，新增测试有 3 个失败；恢复修复后全过。测试通过不等于测试有效，这一步单独验了。

## 验证

在 Node 20 + Linux 上针对**当前 main**（含 v0.1.4）执行：

- ✅ `tsc --noEmit` 通过
- ✅ 131 个测试全过（6 个平台专属用例按既有约定跳过）
- ✅ 修复后 `findSystemNodeRuntime()` 由返回 `null` 变为正确返回 `bin/node`、`bin/npm`、`bin/npx`

## 来源说明

这个修复原本在 PR #4 里（commit `3c12cf8`），但 PR #5 的整合分支是从 `3b5ec54` 切的，比它早一步，所以没搭上车。本 PR 把它重新基于当前 main 提出，冲突（`node-runtime.test.ts` 的 import 块与 v0.1.4 新增的 `PNPM_VERSION`）已解决。

## 建议顺带一看

`0638eab`（修 `pnpmExecutable` 断言）与本 PR 修的是**同一类问题的不同实例** —— Windows-only 的假设在 Linux 上失效。CI 上线后已经抓出两处，值得留意是否还有第三处。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
