### PR TITLE
feat: persist catalog analysis and manage skills

### DIFF
--- a/electron/installer.ts
+++ b/electron/installer.ts
@@ -33,7 +33,7 @@ import { readPluginReceipts, recordPluginInstall } from './plugin-receipts'
 import { readProfile } from './profile'
 import { withExecutableDirectoryOnPath } from './process'
 import { analyzeSkillRepository } from './skill-catalog'
-import { readInstalledSkills as readLocalSkills } from './skill-format'
+import { readInstalledSkills as readLocalSkills, toggleInstalledSkill } from './skill-format'
 import { installSkillFromRepository } from './skill-install'
 
 /**
@@ -92,6 +92,8 @@ export interface Installer {
   installSkill(request: SkillInstallRequest): Promise<SkillInstallResult>
   /** 读取已安装的 Skill 列表。 */
   readInstalledSkills(): Promise<InstalledSkill[]>
+  /** 启用或停用一个本地 Skill。 */
+  toggleSkill(name: string, enabled: boolean): Promise<InstalledSkill[]>
   /** 汇总当前 Profile 与安装凭据里已安装的仓库，用于在列表中标记「已安装」。 */
   listInstalledRepositories(): Promise<string[]>
   /** 从当前 Profile 中卸载一个插件。 */
@@ -419,6 +421,11 @@ export function createInstaller(options: InstallerOptions): Installer {
     async readInstalledSkills(): Promise<InstalledSkill[]> {
       const settings = await options.readSettings()
       return readLocalSkills(settings.dshHome)
+    },
+
+    async toggleSkill(name: string, enabled: boolean): Promise<InstalledSkill[]> {
+      const settings = await options.readSettings()
+      return toggleInstalledSkill(settings.dshHome, name, Boolean(enabled))
     },
 
     async listInstalledRepositories(): Promise<string[]> {

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -119,6 +119,12 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
     return installer.installSkill(request)
   })
   ipcMain.handle(IPC.skillsReadInstalled, () => installer.readInstalledSkills())
+  ipcMain.handle(IPC.skillsToggle, async (_event, payload: { name: string; enabled: boolean }) => {
+    if (!payload || typeof payload.name !== 'string' || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(payload.name)) {
+      throw new Error('Skill 名称无效。')
+    }
+    return installer.toggleSkill(payload.name, Boolean(payload.enabled))
+  })
 
   ipcMain.handle(IPC.runtimeState, () => runtime.state())
   ipcMain.handle(IPC.runtimeStart, () => runtime.start())

--- a/electron/plugin-catalog.ts
+++ b/electron/plugin-catalog.ts
@@ -9,6 +9,7 @@ import { isSafePackageName, isSafeRepositoryName, repositoryFullNameFromSpecifie
 interface PackageManifest {
   name?: string
   version?: string
+  gitHead?: string
   private?: boolean
   workspaces?: unknown
   repository?: string | { url?: string }
@@ -112,6 +113,62 @@ async function publishedPackage(
   return manifest.name === packageName ? manifest : null
 }
 
+/** Verify a published root Bundle without relying on the GitHub API quota. */
+async function analyzePublishedRootPlugin(
+  repository: string,
+  defaultBranch: string,
+  currentProfile: string,
+  fetchImpl: typeof fetch,
+): Promise<RepositoryAnalysis | null> {
+  const rootManifest = await fetchOptionalManifest(rawFileUrl(repository, defaultBranch, 'package.json'), fetchImpl)
+  if (!rootManifest?.name || !isSafePackageName(rootManifest.name) || !rootManifest.dsh?.bundle?.patch) return null
+  if (rootManifest.dsh.type === 'dynamic-plugin') {
+    return {
+      repository,
+      defaultBranch,
+      installability: 'dynamic',
+      summary: 'This is a session-only dynamic plugin.',
+      targets: [],
+    }
+  }
+  if (rootManifest.name === '@deepseek-ai/dsh-root') {
+    return {
+      repository,
+      defaultBranch,
+      installability: 'application',
+      summary: 'This is the DeepSeek Harness source workspace.',
+      targets: [],
+    }
+  }
+
+  const published = await publishedPackage(rootManifest.name, repository, fetchImpl)
+  if (!published) return null
+  const profile = recommendedProfile(published, currentProfile)
+  const commit = published.gitHead && /^[a-f0-9]{40}$/i.test(published.gitHead)
+    ? published.gitHead
+    : defaultBranch
+  const buildScripts = lifecycleScripts(rootManifest, 'npm')
+  return {
+    repository,
+    defaultBranch,
+    installability: 'ready',
+    summary: `Detected installable ${published.name ?? rootManifest.name}.`,
+    targets: [{
+      id: targetId(rootManifest.name, ''),
+      packageName: rootManifest.name,
+      version: published.version ?? rootManifest.version ?? null,
+      source: 'npm',
+      profileName: profile.name,
+      platform: profile.platform,
+      subdirectory: null,
+      commit,
+      requiresBuild: buildScripts.length > 0,
+      buildScripts,
+      nodeRange: published.engines?.node ?? rootManifest.engines?.node ?? null,
+    }],
+  }
+}
+
 function candidatePatchPath(directory: string, patchFile: string): string | null {
   if (!patchFile || path.posix.isAbsolute(patchFile)) return null
   const normalized = path.posix.normalize(path.posix.join(directory, patchFile))
@@ -189,12 +246,19 @@ export async function analyzeRepository(
 ): Promise<RepositoryAnalysis> {
   if (!isSafeRepositoryName(repository) || !safeBranch(defaultBranch)) throw new Error('仓库名称或默认分支无效。')
 
-  const commitResult = await fetchJson<{ sha?: string }>(
-    githubApiPath(repository, `commits/${encodeURIComponent(defaultBranch)}`),
-    fetchImpl,
-  )
-  const commit = commitResult.sha
-  if (!commit || !/^[a-f0-9]{40}$/i.test(commit)) throw new Error('GitHub 没有返回有效的提交版本。')
+  let commit: string
+  try {
+    const commitResult = await fetchJson<{ sha?: string }>(
+      githubApiPath(repository, `commits/${encodeURIComponent(defaultBranch)}`),
+      fetchImpl,
+    )
+    commit = commitResult.sha ?? ''
+    if (!/^[a-f0-9]{40}$/i.test(commit)) throw new Error('GitHub 没有返回有效的提交版本。')
+  } catch (error) {
+    const fallback = await analyzePublishedRootPlugin(repository, defaultBranch, currentProfile, fetchImpl).catch(() => null)
+    if (fallback) return fallback
+    throw error
+  }
 
   const rootManifest = await fetchOptionalManifest(rawFileUrl(repository, commit, 'package.json'), fetchImpl)
   if (rootManifest?.dsh?.type === 'dynamic-plugin') {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -31,6 +31,7 @@ const api: LauncherApi = {
   uninstallPlugin: packageName => ipcRenderer.invoke(IPC.pluginsUninstall, packageName),
   installSkill: request => ipcRenderer.invoke(IPC.skillsInstall, request),
   readInstalledSkills: () => ipcRenderer.invoke(IPC.skillsReadInstalled),
+  toggleSkill: (name, enabled) => ipcRenderer.invoke(IPC.skillsToggle, { name, enabled }),
   getRuntimeState: () => ipcRenderer.invoke(IPC.runtimeState),
   startRuntime: () => ipcRenderer.invoke(IPC.runtimeStart),
   stopRuntime: () => ipcRenderer.invoke(IPC.runtimeStop),

--- a/electron/skill-format.ts
+++ b/electron/skill-format.ts
@@ -1,4 +1,5 @@
-import { readdir, readFile } from 'node:fs/promises'
+import { mkdir, readdir, readFile, rename } from 'node:fs/promises'
+import type { Dirent } from 'node:fs'
 import path from 'node:path'
 import { parse } from 'yaml'
 import type { InstalledSkill } from '../src/types'
@@ -83,33 +84,68 @@ export function parseSkillDocument(raw: string): ParsedSkill | null {
 
 export async function readInstalledSkills(dshHome: string): Promise<InstalledSkill[]> {
   const root = path.join(dshHome, 'skills')
-  let entries
-  try {
-    entries = await readdir(root, { withFileTypes: true })
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
-    throw error
-  }
-
   const installed: InstalledSkill[] = []
-  for (const entry of entries) {
-    const format = entry.isDirectory() ? 'bundle' : entry.isFile() && entry.name.toLowerCase().endsWith('.md') ? 'flat' : null
-    if (!format || entry.name === '.system') continue
-    const skillPath = format === 'bundle' ? path.join(root, entry.name, 'SKILL.md') : path.join(root, entry.name)
+  const readEntries = async (sourceRoot: string, enabled: boolean): Promise<void> => {
+    let sourceEntries: Dirent<string>[]
     try {
-      const parsed = parseSkillDocument(await readFile(skillPath, 'utf8'))
-      if (!parsed) continue
-      installed.push({
-        name: parsed.name,
-        description: parsed.description,
-        path: format === 'bundle' ? path.dirname(skillPath) : skillPath,
-        format,
-        modelInvocable: parsed.modelInvocable,
-        userInvocable: parsed.userInvocable,
-      })
+      sourceEntries = await readdir(sourceRoot, { withFileTypes: true })
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+      throw error
+    }
+    for (const entry of sourceEntries) {
+      const format = entry.isDirectory() ? 'bundle' : entry.isFile() && entry.name.toLowerCase().endsWith('.md') ? 'flat' : null
+      if (!format || entry.name === '.system') continue
+      const skillPath = format === 'bundle' ? path.join(sourceRoot, entry.name, 'SKILL.md') : path.join(sourceRoot, entry.name)
+      try {
+        const parsed = parseSkillDocument(await readFile(skillPath, 'utf8'))
+        if (!parsed) continue
+        installed.push({
+          name: parsed.name,
+          description: parsed.description,
+          path: format === 'bundle' ? path.dirname(skillPath) : skillPath,
+          format,
+          enabled,
+          modelInvocable: parsed.modelInvocable,
+          userInvocable: parsed.userInvocable,
+        })
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+      }
     }
   }
-  return installed.sort((left, right) => left.name.localeCompare(right.name))
+
+  await readEntries(root, true)
+  await readEntries(path.join(root, '.disabled'), false)
+  const unique = new Map<string, InstalledSkill>()
+  for (const skill of installed) {
+    const previous = unique.get(skill.name)
+    if (!previous || skill.enabled || !previous.enabled) unique.set(skill.name, skill)
+  }
+  return [...unique.values()].sort((left, right) => left.name.localeCompare(right.name))
+}
+
+/** Move a Skill between the DSH-visible root and the hidden disabled directory. */
+export async function toggleInstalledSkill(dshHome: string, name: string, enabled: boolean): Promise<InstalledSkill[]> {
+  const root = path.join(dshHome, 'skills')
+  const current = await readInstalledSkills(dshHome)
+  const skill = current.find(item => item.name === name)
+  if (!skill) throw new Error(`未找到本地 Skill：${name}`)
+  if (skill.enabled === enabled) return current
+
+  const disabledRoot = path.join(root, '.disabled')
+  const source = skill.path
+  const destination = enabled
+    ? path.join(root, skill.format === 'bundle' ? path.basename(source) : path.basename(source))
+    : path.join(disabledRoot, skill.format === 'bundle' ? path.basename(source) : path.basename(source))
+  await mkdir(path.dirname(destination), { recursive: true })
+  try {
+    await rename(source, destination)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST' || (error as NodeJS.ErrnoException).code === 'EPERM') {
+      throw new Error(`无法${enabled ? '启用' : '停用'} Skill「${name}」：目标位置已存在同名文件`)
+    }
+    throw error
+  }
+  return readInstalledSkills(dshHome)
 }

--- a/electron/skill-install.ts
+++ b/electron/skill-install.ts
@@ -182,14 +182,26 @@ export async function installSkillFromRepository(
       : path.join(skillRoot, target.name)
     assertInside(skillRoot, destination)
     assertInside(skillRoot, conflicting)
+    const disabledRoot = path.join(skillRoot, '.disabled')
+    const disabledDestination = target.format === 'bundle'
+      ? path.join(disabledRoot, target.name)
+      : path.join(disabledRoot, `${target.name}.md`)
+    const disabledConflicting = target.format === 'bundle'
+      ? path.join(disabledRoot, `${target.name}.md`)
+      : path.join(disabledRoot, target.name)
+    assertInside(skillRoot, disabledDestination)
+    assertInside(skillRoot, disabledConflicting)
     await replacePath(staged, destination)
     await rm(conflicting, { recursive: true, force: true })
+    await rm(disabledDestination, { recursive: true, force: true })
+    await rm(disabledConflicting, { recursive: true, force: true })
     onProgress(96, '正在验证本地 Skill')
     return {
       name: parsed.name,
       description: parsed.description,
       path: destination,
       format: target.format,
+      enabled: true,
       modelInvocable: parsed.modelInvocable,
       userInvocable: parsed.userInvocable,
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,10 +115,12 @@ function LauncherShell() {
               {navigation.view === 'plugins' && (
                 <PluginsView
                   profile={profile}
+                  installedSkills={store.installedSkills}
                   selected={store.selected}
                   busy={store.busy}
                   onSelect={plugin => store.selectPlugin(plugin.packageName)}
                   onToggle={store.togglePlugin}
+                  onToggleSkill={store.toggleSkill}
                   onReorder={store.reorderPlugins}
                   onRefresh={store.refreshProfile}
                   onBrowse={() => navigation.setView('discover')}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,6 +38,7 @@ export const IPC = {
   pluginsUninstall: 'plugins:uninstall',
   skillsInstall: 'skills:install',
   skillsReadInstalled: 'skills:read-installed',
+  skillsToggle: 'skills:toggle',
   runtimeState: 'runtime:state',
   runtimeStart: 'runtime:start',
   runtimeStop: 'runtime:stop',

--- a/src/demo-api.ts
+++ b/src/demo-api.ts
@@ -76,7 +76,7 @@ let demoPlugins: ManagedPlugin[] = [
     order: 4,
   },
   {
-    packageName: '@ccch1mneyyy/dsh-tui',
+    packageName: '@deepseek-harness-tui/dsh-tui',
     displayName: 'DSH TUI',
     version: '2.3.0',
     description: 'Claude Code 风格的全屏终端交互界面。',
@@ -143,7 +143,7 @@ function demoAnalysis(fullName: string, defaultBranch: string): RepositoryAnalys
   const packageName = fullName === 'liustack/modlens'
     ? '@liustack/modlens'
     : fullName === 'ccch1mneyyy/dsh-TUI'
-      ? 'dsh-cc-tui'
+      ? '@deepseek-harness-tui/dsh-tui'
       : fullName === 'omdsh-dev/DSH-better-sidebar'
         ? 'dsh-better-sidebar'
         : `@${repo?.owner ?? 'demo'}/${(repo?.name ?? 'plugin').toLowerCase()}`
@@ -157,8 +157,8 @@ function demoAnalysis(fullName: string, defaultBranch: string): RepositoryAnalys
       packageName,
       version: '1.0.0',
       source: 'npm',
-      profileName: packageName === 'dsh-cc-tui' ? 'cc-tui' : 'web',
-      platform: packageName === 'dsh-cc-tui' ? 'terminal' : 'web',
+      profileName: packageName === '@deepseek-harness-tui/dsh-tui' ? 'cc-tui' : 'web',
+      platform: packageName === '@deepseek-harness-tui/dsh-tui' ? 'terminal' : 'web',
       subdirectory: null,
       commit: 'a'.repeat(40),
       requiresBuild: false,
@@ -334,6 +334,7 @@ export const demoApi: LauncherApi = {
       description: target.description,
       path: `${demoSettings.dshHome}\\skills\\${target.name}`,
       format: target.format,
+      enabled: true,
       modelInvocable: target.modelInvocable,
       userInvocable: target.userInvocable,
     }
@@ -342,6 +343,10 @@ export const demoApi: LauncherApi = {
     return { installedSkill, installedSkills: demoInstalledSkills }
   },
   readInstalledSkills: async () => demoInstalledSkills,
+  toggleSkill: async (name, enabled) => {
+    demoInstalledSkills = demoInstalledSkills.map(skill => skill.name === name ? { ...skill, enabled } : skill)
+    return demoInstalledSkills
+  },
   getRuntimeState: async () => demoRuntime,
   startRuntime: async () => {
     demoRuntime = { running: true, pid: 18420, startedAt: new Date().toISOString(), url: 'http://127.0.0.1:3080' }

--- a/src/hooks/use-launcher-store.ts
+++ b/src/hooks/use-launcher-store.ts
@@ -59,13 +59,15 @@ export function useLauncherStore() {
       api.getRuntimeState(),
       api.getDeepSeekCredentialStatus(),
       api.detectDshInstallation(),
+      api.readInstalledSkills(),
     ])
-      .then(([nextSettings, nextProfile, nextRuntime, nextCredentialStatus, nextDshInstallation]) => {
+      .then(([nextSettings, nextProfile, nextRuntime, nextCredentialStatus, nextDshInstallation, nextInstalledSkills]) => {
         setSettings(nextSettings)
         setProfile(nextProfile)
         setRuntime(nextRuntime)
         setCredentialStatus(nextCredentialStatus)
         setDshInstallation(nextDshInstallation)
+        setInstalledSkills(nextInstalledSkills)
         setSelectedPlugin(nextProfile.plugins[0]?.packageName ?? null)
       })
       .catch(error => showToast({ kind: 'error', message: errorText(error) }))
@@ -181,6 +183,13 @@ export function useLauncherStore() {
     if (next) setProfile(next)
   }, [api, run])
 
+  const toggleSkill = useCallback(async (skill: InstalledSkill, enabled: boolean) => {
+    const next = await run(`skill:${skill.name}`, () => api.toggleSkill(skill.name, enabled), {
+      success: enabled ? `Skill「${skill.name}」已启用。` : `Skill「${skill.name}」已停用。`,
+    })
+    if (next) setInstalledSkills(next)
+  }, [api, run])
+
   /** 先本地重排让拖拽有即时反馈，主进程写盘失败再回滚。 */
   const reorderPlugins = useCallback(async (packageNames: string[]) => {
     if (!profile) return
@@ -238,6 +247,7 @@ export function useLauncherStore() {
     saveApiKey,
     clearApiKey,
     togglePlugin,
+    toggleSkill,
     reorderPlugins,
     uninstallPlugin,
   }

--- a/src/lib/catalog-cache.ts
+++ b/src/lib/catalog-cache.ts
@@ -1,0 +1,70 @@
+import type { CatalogRepositoryAnalysis } from '../types'
+
+const STORAGE_KEY = 'dsh-launcher.catalog-analysis.v2'
+const memoryCache = new Map<string, CatalogCacheEntry>()
+
+export interface CatalogCacheEntry {
+  repository: string
+  defaultBranch: string
+  analysis: CatalogRepositoryAnalysis
+  cachedAt: number
+}
+
+function cacheKey(repository: string, defaultBranch: string): string {
+  return `${repository.toLowerCase()}#${defaultBranch}`
+}
+
+function readStorage(): Record<string, CatalogCacheEntry> {
+  try {
+    if (typeof localStorage === 'undefined') return {}
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return {}
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    return parsed as Record<string, CatalogCacheEntry>
+  } catch {
+    return {}
+  }
+}
+
+function writeStorage(entries: Record<string, CatalogCacheEntry>): void {
+  try {
+    if (typeof localStorage !== 'undefined') localStorage.setItem(STORAGE_KEY, JSON.stringify(entries))
+  } catch {
+    // Private browsing and quota errors fall back to the in-memory cache.
+  }
+}
+
+export function readCatalogAnalysisCache(
+  repository: string,
+  defaultBranch: string,
+  maxAgeMs = 24 * 60 * 60 * 1000,
+): CatalogRepositoryAnalysis | null {
+  const key = cacheKey(repository, defaultBranch)
+  const stored = readStorage()[key] ?? memoryCache.get(key)
+  if (!stored || Date.now() - stored.cachedAt > maxAgeMs || stored.repository.toLowerCase() !== repository.toLowerCase()) return null
+  memoryCache.set(key, stored)
+  return stored.analysis
+}
+
+export function writeCatalogAnalysisCache(
+  repository: string,
+  defaultBranch: string,
+  analysis: CatalogRepositoryAnalysis,
+): void {
+  const key = cacheKey(repository, defaultBranch)
+  const entry: CatalogCacheEntry = { repository, defaultBranch, analysis, cachedAt: Date.now() }
+  memoryCache.set(key, entry)
+  const entries = readStorage()
+  entries[key] = entry
+  writeStorage(entries)
+}
+
+export function clearCatalogAnalysisCache(): void {
+  memoryCache.clear()
+  try {
+    if (typeof localStorage !== 'undefined') localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // Ignore unavailable storage.
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -870,6 +870,127 @@ input:focus-visible {
   border-right: 1px solid var(--line);
 }
 
+.plugin-management-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 0.42fr);
+  min-width: 0;
+}
+
+.plugin-management-column {
+  min-width: 0;
+  border-right: 1px solid var(--line);
+}
+
+.plugin-management-column .column-headings,
+.plugin-management-column .plugin-row {
+  grid-template-columns: 62px minmax(140px, 1fr) 72px 58px 56px;
+}
+
+.skill-management-column {
+  min-width: 0;
+  background: #fbfcfb;
+}
+
+.skill-column-heading {
+  display: flex;
+  min-height: 31px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--line);
+  color: var(--quiet);
+  background: var(--surface-soft);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.skill-column-heading > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--ink);
+}
+
+.skill-column-heading small {
+  color: var(--quiet);
+  font-size: 10px;
+  font-weight: 500;
+}
+
+.skill-row {
+  display: flex;
+  min-height: 64px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 12px;
+  gap: 10px;
+  border-bottom: 1px solid #e8ebe8;
+  background: #fff;
+}
+
+.skill-row .switch {
+  flex: 0 0 35px;
+}
+
+.skill-row.disabled {
+  color: var(--muted);
+  background: #f7f9f7;
+}
+
+.skill-identity {
+  display: grid;
+  flex: 1 1 auto;
+  width: 0;
+  min-width: 0;
+  grid-template-columns: 28px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+}
+
+.skill-glyph {
+  display: grid;
+  width: 27px;
+  height: 27px;
+  place-items: center;
+  border: 1px solid #bddae0;
+  border-radius: 6px;
+  color: #236a76;
+  background: #edf7f8;
+}
+
+.skill-identity > div:last-child {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.skill-identity strong,
+.skill-identity span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.skill-identity strong {
+  color: var(--ink);
+  font-size: 12px;
+}
+
+.skill-identity span {
+  color: var(--quiet);
+  font-size: 10px;
+}
+
+.skill-empty {
+  display: grid;
+  min-height: 110px;
+  place-items: center;
+  padding: 14px;
+  color: var(--quiet);
+  font-size: 11px;
+}
+
 .list-toolbar {
   display: flex;
   min-height: 53px;
@@ -2797,11 +2918,23 @@ input:focus-visible {
   }
 
   .plugin-layout {
-    min-width: 650px;
+    min-width: 0;
   }
 
   .plugins-page {
-    overflow-x: auto;
+    overflow-x: hidden;
+  }
+
+  .plugin-management-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .plugin-management-column {
+    border-right: 0;
+  }
+
+  .skill-management-column {
+    border-top: 1px solid var(--line);
   }
 
   .discovery-controls {

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,6 +123,7 @@ export interface InstalledSkill {
   description: string
   path: string
   format: 'bundle' | 'flat'
+  enabled: boolean
   modelInvocable: boolean
   userInvocable: boolean
 }
@@ -211,6 +212,7 @@ export interface LauncherApi {
   uninstallPlugin(packageName: string): Promise<ProfileState>
   installSkill(request: SkillInstallRequest): Promise<SkillInstallResult>
   readInstalledSkills(): Promise<InstalledSkill[]>
+  toggleSkill(name: string, enabled: boolean): Promise<InstalledSkill[]>
   getRuntimeState(): Promise<RuntimeState>
   startRuntime(): Promise<RuntimeState>
   stopRuntime(): Promise<RuntimeState>

--- a/src/views/DiscoverView.tsx
+++ b/src/views/DiscoverView.tsx
@@ -23,6 +23,7 @@ import { CatalogPagination } from '../components/CatalogPagination'
 import { PageHeading } from '../components/PageHeading'
 import { EMPTY_DSH_INSTALLATION } from '../constants'
 import { errorText, formatBytes, formatRelativeTime, formatStars } from '../lib/format'
+import { readCatalogAnalysisCache, writeCatalogAnalysisCache } from '../lib/catalog-cache'
 import { isInstallProgressActive } from '../lib/install-progress'
 import type {
   CatalogRepositoryAnalysis,
@@ -140,12 +141,16 @@ export function DiscoverView({
       setWarnings(result.warnings)
       setDshInstallation(result.dshInstallation)
       onInstallationState(result.installedRepositories, result.installedSkills)
+      for (const repo of result.repositories) {
+        const cached = readCatalogAnalysisCache(repo.fullName, repo.defaultBranch)
+        if (cached) onAnalysis(repo.fullName, cached)
+      }
     } catch (error) {
       onError(errorText(error))
     } finally {
       setLoading(false)
     }
-  }, [api, onError, onInstallationState, page, query, sort])
+  }, [api, onAnalysis, onError, onInstallationState, page, query, sort])
 
   useEffect(() => { void search('', 'stars', 1) }, [])
   useEffect(() => () => { batchRunRef.current += 1 }, [])
@@ -172,6 +177,7 @@ export function DiscoverView({
     setChecking(repo.fullName)
     try {
       const analysis = await api.analyzeCatalogRepository(repo.fullName, repo.defaultBranch)
+      if (analysis.warnings.length === 0) writeCatalogAnalysisCache(repo.fullName, repo.defaultBranch, analysis)
       onAnalysis(repo.fullName, analysis)
       if (analysis.kind === 'hybrid'
         || pluginTargets(analysis).length + skillTargets(analysis).length > 1) {
@@ -203,6 +209,7 @@ export function DiscoverView({
       setChecking(repo.fullName)
       try {
         const analysis = await api.analyzeCatalogRepository(repo.fullName, repo.defaultBranch)
+        if (analysis.warnings.length === 0) writeCatalogAnalysisCache(repo.fullName, repo.defaultBranch, analysis)
         if (batchRunRef.current !== runId) return
         onAnalysis(repo.fullName, analysis)
         if (analysis.kind !== 'invalid') available += 1

--- a/src/views/PluginsView.tsx
+++ b/src/views/PluginsView.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowDown,
   ArrowUp,
+  BookOpenCheck,
   CircleAlert,
   Download,
   ExternalLink,
@@ -20,16 +21,18 @@ import { useState } from 'react'
 import { PageHeading } from '../components/PageHeading'
 import { pluginInitial } from '../lib/format'
 import { movePackage, movePackageTo } from '../lib/profile-order'
-import type { ManagedPlugin, ProfileState } from '../types'
+import type { InstalledSkill, ManagedPlugin, ProfileState } from '../types'
 
 /** 插件加载顺序页：列表、排序、启停与详情。 */
 
 interface PluginsViewProps {
   profile: ProfileState
+  installedSkills: InstalledSkill[]
   selected: ManagedPlugin | null
   busy: string | null
   onSelect: (plugin: ManagedPlugin) => void
   onToggle: (plugin: ManagedPlugin, enabled: boolean) => void
+  onToggleSkill: (skill: InstalledSkill, enabled: boolean) => void
   onReorder: (names: string[]) => void
   onRefresh: () => void
   onBrowse: () => void
@@ -40,10 +43,12 @@ interface PluginsViewProps {
 
 export function PluginsView({
   profile,
+  installedSkills,
   selected,
   busy,
   onSelect,
   onToggle,
+  onToggleSkill,
   onReorder,
   onRefresh,
   onBrowse,
@@ -107,6 +112,8 @@ export function PluginsView({
               </label>
               <span>{active.length} 个加载层</span>
             </div>
+            <div className="plugin-management-grid">
+              <div className="plugin-management-column">
             <div className="column-headings" aria-hidden="true">
               <span>优先级</span><span>插件</span><span>版本</span><span>状态</span><span />
             </div>
@@ -145,12 +152,55 @@ export function PluginsView({
                 />
               ))}
             </div>
+              </div>
+              <SkillList skills={installedSkills.filter(skill => visibleSkill(skill, filter))} busy={busy} onToggle={onToggleSkill} />
+            </div>
           </section>
           <PluginDetails
             plugin={selected}
             onOpenRepository={onOpenRepository}
             onUninstall={onUninstall}
           />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function visibleSkill(skill: InstalledSkill, filter: string): boolean {
+  return !filter || `${skill.name} ${skill.description}`.toLowerCase().includes(filter.toLowerCase())
+}
+
+function SkillList({ skills, busy, onToggle }: {
+  skills: InstalledSkill[]
+  busy: string | null
+  onToggle: (skill: InstalledSkill, enabled: boolean) => void
+}) {
+  return (
+    <div className="skill-management-column">
+      <div className="skill-column-heading"><span><BookOpenCheck size={14} />Skill</span><small>{skills.length} 个已安装</small></div>
+      {skills.length === 0 ? (
+        <div className="skill-empty">尚未安装 Skill</div>
+      ) : (
+        <div className="skill-rows">
+          {skills.map(skill => (
+            <div className={`skill-row ${skill.enabled ? '' : 'disabled'}`} key={skill.name}>
+              <div className="skill-identity">
+                <div className="skill-glyph"><BookOpenCheck size={15} /></div>
+                <div><strong>{skill.name}</strong><span>{skill.description}</span></div>
+              </div>
+              <label className="switch" title={skill.enabled ? '停用 Skill' : '启用 Skill'}>
+                <input
+                  type="checkbox"
+                  checked={skill.enabled}
+                  disabled={busy === `skill:${skill.name}`}
+                  onChange={event => onToggle(skill, event.target.checked)}
+                  aria-label={`${skill.enabled ? '停用' : '启用'} Skill ${skill.name}`}
+                />
+                <span>{busy === `skill:${skill.name}` && <LoaderCircle className="spin" size={11} />}</span>
+              </label>
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/tests/plugin-catalog.integration.test.ts
+++ b/tests/plugin-catalog.integration.test.ts
@@ -9,7 +9,7 @@ integrationTest('classifies representative live dsh-plugin repositories', async 
   const desktop = await analyzeRepository('anywhere-labs/deepseek-harness-desktop', 'master', 'web')
   const dynamic = await analyzeRepository('mervyn-teo/dsh-plugin-qr-connect', 'main', 'web')
 
-  expect(tui.targets[0]).toMatchObject({ packageName: 'dsh-cc-tui', source: 'npm', profileName: 'cc-tui' })
+  expect(tui.targets[0]).toMatchObject({ packageName: '@deepseek-harness-tui/dsh-tui', source: 'npm', profileName: 'cc-tui' })
   expect(skin.targets[0]).toMatchObject({
     packageName: '@dsh-external/dsh-client-ui-skin-maid-atelier',
     source: 'archive-subdirectory',

--- a/tests/plugin-catalog.test.ts
+++ b/tests/plugin-catalog.test.ts
@@ -153,4 +153,27 @@ describe('repository plugin analysis', () => {
     expect(analysis.installability).toBe('application')
     expect(analysis.targets).toEqual([])
   })
+
+  it('falls back to a published root plugin when GitHub API quota is exhausted', async () => {
+    const repository = 'demo/dsh-tui'
+    const manifest = {
+      name: '@demo/dsh-tui',
+      version: '0.6.1',
+      repository: `https://github.com/${repository}.git`,
+      dsh: { bundle: { patch: './cordis.patch.yml' } },
+    }
+    const analysis = await analyzeRepository(repository, 'main', 'web', mockFetch({
+      [commitUrl(repository)]: json({ message: 'rate limited' }, 403),
+      ['https://raw.githubusercontent.com/demo/dsh-tui/main/package.json']: json(manifest),
+      ['https://registry.npmjs.org/%40demo%2Fdsh-tui/latest']: json(manifest),
+    }))
+
+    expect(analysis).toMatchObject({ installability: 'ready' })
+    expect(analysis.targets[0]).toMatchObject({
+      packageName: '@demo/dsh-tui',
+      source: 'npm',
+      profileName: 'cc-tui',
+      commit: 'main',
+    })
+  })
 })

--- a/tests/skill-format.test.ts
+++ b/tests/skill-format.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { parseSkillDocument, readInstalledSkills } from '../electron/skill-format'
+import { parseSkillDocument, readInstalledSkills, toggleInstalledSkill } from '../electron/skill-format'
 
 const temporaryRoots: string[] = []
 
@@ -47,5 +47,19 @@ user-invocable: no
       ['bundle-skill', 'bundle'],
       ['flat-skill', 'flat'],
     ])
+    expect(installed.every(skill => skill.enabled)).toBe(true)
+  })
+
+  it('moves a skill into a hidden directory while disabled', async () => {
+    const dshHome = await mkdtemp(path.join(os.tmpdir(), 'dsh-skill-toggle-'))
+    temporaryRoots.push(dshHome)
+    await mkdir(path.join(dshHome, 'skills', 'toggle-skill'), { recursive: true })
+    await writeFile(path.join(dshHome, 'skills', 'toggle-skill', 'SKILL.md'), '---\nname: toggle-skill\ndescription: Toggle me.\n---\nBody\n')
+
+    const disabled = await toggleInstalledSkill(dshHome, 'toggle-skill', false)
+    expect(disabled).toMatchObject([{ name: 'toggle-skill', enabled: false }])
+    expect(disabled[0].path).toContain(`${path.sep}.disabled${path.sep}`)
+    const enabled = await toggleInstalledSkill(dshHome, 'toggle-skill', true)
+    expect(enabled).toMatchObject([{ name: 'toggle-skill', enabled: true }])
   })
 })


### PR DESCRIPTION
## 改动内容

- 在管理首页加入 Skill 启用/停用控制，并将停用项安全移至 `.disabled` 目录
- 将资源市场检测结果在本地缓存 24 小时，手动检测仍会强制刷新
- GitHub API 额度耗尽时，通过 raw package.json 与 npm registry 回退识别 Plugin
- 修正 Skill 开关布局和窄窗口响应式排列，避免控件被挤出容器
- 更新渲染层、IPC、演示 API 与类型契约，并补充检测和格式测试

## 改动类型

- [ ] 缺陷修复
- [x] 新功能
- [ ] 重构（不改变外部行为）
- [ ] 文档
- [ ] 构建 / CI

## 验证方式

- [x] `npm test -- --run` 通过：139 项通过，3 项按环境跳过
- [x] `npm run build` 通过
- [x] 在 Windows 上实际启动开发版验证

## 检查项

- [x] 没有引入与 DSH 官方 Profile 结构不兼容的配置格式
- [x] 已同步更新主进程、预加载层及 `src/types.ts` 的 API 契约
- [x] 无需更新 README

## 补充说明

- 检测缓存版本已升级，旧的错误结果不会继续使用
- 带检测警告的结果不会写入持久缓存
- `ccch1mneyyy/dsh-TUI` 在完整检测下可识别为同时包含 Plugin 与 Skill