### PR TITLE
feat(ai-install): 支持 git 子模块聚合仓库（meta-repo）的 AI 尝试安装

### DIFF
--- a/electron/ai-install.ts
+++ b/electron/ai-install.ts
@@ -37,7 +37,7 @@ import {
   type AcpPermissionRequest,
   type AcpTransport,
 } from './acp-client'
-import { prepareAiRepositorySource, type AiRepositorySource } from './ai-repository-source'
+import { prepareAiRepositorySource, type AiRepositorySource, type SubmoduleInfo } from './ai-repository-source'
 import { runCommand } from './command'
 import type { NodeRuntime, PnpmRuntime } from './node-runtime'
 import { spawnCommand, withExecutableDirectoryOnPath } from './process'
@@ -263,6 +263,10 @@ export interface AiInstallPromptInput {
   shell?: 'bash' | 'pwsh'
   /** 可用的 DSH 命令行前缀（如 `npx --yes @deepseek-ai/dsh`），agent 借它调 plugin add。 */
   dshCliCommand?: string
+  /** 聚合仓库：已预取的 git 子模块（内容已解压到 repositoryPath 对应子目录）。 */
+  submodules?: SubmoduleInfo[]
+  /** 聚合仓库：未能预取的子模块（非 GitHub / 下载失败），agent 不应尝试联网下载。 */
+  skippedSubmodules?: { path: string; reason: string }[]
 }
 
 function classificationLabel(installability: PluginInstallability): string {
@@ -315,6 +319,18 @@ export function buildInstallPrompt(input: AiInstallPromptInput): string {
     ...(analysis.targets.length ? [`市场已识别到可安装目标：${formatTargets(analysis.targets)}`] : []),
     ...(repositoryPath ? [
       `启动器已把仓库安全下载到本地：\`${repositoryPath}\`。必须优先检查这个本地副本，不要重新 clone 或下载仓库。`,
+    ] : []),
+    ...(input.submodules?.length ? [
+      '',
+      '## 聚合仓库（git submodules）',
+      `该仓库通过 .gitmodules 声明了 ${input.submodules.length} 个子模块，每个子模块都是独立的 GitHub 仓库。启动器已把它们的仓库内容预取到本地副本的对应子目录：`,
+      ...input.submodules.map(submodule =>
+        `- \`${repositoryPath}/${submodule.path}/\` ← ${submodule.repository}（${submodule.revision.slice(0, 12)}）`),
+      '可安装的 DSH Bundle 或 Skill 很可能位于这些子模块目录内。请逐个检查子模块目录，找到可安装目标后按研究指引安装；不同子模块可能是插件、也可能是 Skill。',
+    ] : []),
+    ...(input.skippedSubmodules?.length ? [
+      '',
+      `以下子模块未能预取（${input.skippedSubmodules.map(skipped => `${skipped.path}：${skipped.reason}`).join('；')}）。它们的目录是空的，请勿尝试联网下载或 clone。`,
     ] : []),
     '',
     '## 研究指引',
@@ -1423,8 +1439,12 @@ export function createAiInstaller(options: AiInstallerOptions): AiInstaller {
           options.emitOutput('info', `[ai] 仓库下载 ${percent}%（${received}/${total} bytes）`)
         },
         options.githubFetch,
+        text => log(text),
       )
       log(`仓库本地副本已准备：${repositorySource.repositoryPath}`)
+      if (repositorySource.submodules.length > 0 || repositorySource.skippedSubmodules.length > 0) {
+        log(`聚合仓库：${repositorySource.submodules.length} 个子模块已预取，${repositorySource.skippedSubmodules.length} 个跳过`)
+      }
 
       const prompt = buildInstallPrompt({
         repository: input.repository,
@@ -1433,6 +1453,8 @@ export function createAiInstaller(options: AiInstallerOptions): AiInstaller {
         profileName: settings.profileName,
         workspace: settings.dshHome,
         repositoryPath: repositorySource.repositoryPath,
+        submodules: repositorySource.submodules,
+        skippedSubmodules: repositorySource.skippedSubmodules,
         shell: process.platform === 'win32' ? 'pwsh' : 'bash',
         dshCliCommand: dshCliCommandHint(settings),
       })

--- a/electron/ai-repository-source.ts
+++ b/electron/ai-repository-source.ts
@@ -1,4 +1,5 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import AdmZip from 'adm-zip'
 import { downloadGitHubArchive, githubArchiveUrl } from './github-archive'
@@ -11,6 +12,25 @@ const MAX_UNPACKED_BYTES = 256 * 1024 * 1024
 export interface AiRepositorySource {
   taskRoot: string
   repositoryPath: string
+  /** 已预取的 git 子模块（独立 GitHub 仓库）。 */
+  submodules: SubmoduleInfo[]
+  /** 无法预取的子模块（非 GitHub / 下载失败），附原因。 */
+  skippedSubmodules: { path: string; reason: string }[]
+}
+
+export interface SubmoduleInfo {
+  /** 子模块在 meta-repo 内的相对路径，如 injector。 */
+  path: string
+  /** 子模块的 GitHub 仓库全名（owner/repo）。 */
+  repository: string
+  /** 预取的 revision：gitlink 精确 commit；解析失败时为回退分支名。 */
+  revision: string
+}
+
+/** 主仓库与所有子模块共享的解压预算（跨压缩包累计）。 */
+interface UnpackBudget {
+  files: number
+  bytes: number
 }
 
 function safeRevision(value: string): boolean {
@@ -53,10 +73,210 @@ async function readArchiveResponse(
   return Buffer.concat(chunks, received)
 }
 
+// ---------------------------------------------------------------------------
+// .gitmodules 解析（git config INI 子集）
+// ---------------------------------------------------------------------------
+
+export interface GitSubmoduleDecl {
+  name: string
+  path: string
+  url: string
+  branch?: string
+}
+
+/**
+ * 解析 .gitmodules：取 `[submodule "name"]` 段内的 path / url / branch。
+ * 忽略注释与其它段；缺 path 或 url 的声明丢弃（submodules 用 gitlink 管理，
+ * 缺 url 无法下载，缺 path 无法落盘）。
+ */
+export function parseGitModules(content: string): GitSubmoduleDecl[] {
+  const submodules: GitSubmoduleDecl[] = []
+  let current: GitSubmoduleDecl | null = null
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#') || line.startsWith(';')) continue
+    const sectionMatch = /^\[submodule\s+"([^"]+)"\]$/i.exec(line)
+    if (sectionMatch) {
+      current = { name: sectionMatch[1], path: '', url: '' }
+      submodules.push(current)
+      continue
+    }
+    if (line.startsWith('[')) {
+      current = null
+      continue
+    }
+    if (!current) continue
+    const eqIndex = line.indexOf('=')
+    if (eqIndex < 0) continue
+    const key = line.slice(0, eqIndex).trim().toLowerCase()
+    const value = line.slice(eqIndex + 1).trim()
+    if (key === 'path' && !current.path) current.path = value
+    else if (key === 'url' && !current.url) current.url = value
+    else if (key === 'branch') current.branch = value
+  }
+  return submodules.filter(submodule => Boolean(submodule.path && submodule.url))
+}
+
+const GITHUB_SUBMODULE_URL_PATTERNS = [
+  /^(?:git\+https?:\/\/|https?:\/\/)?github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?\/?$/,
+  /^(?:ssh:\/\/)?git@github\.com[:/]([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?\/?$/,
+  /^github:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)$/,
+]
+
+/**
+ * 从子模块 URL 推导 GitHub 仓库全名（owner/repo）。只接受 github.com 托管；
+ * 非 GitHub 主机、多余路径段或非法仓库名返回 null（调用方跳过该子模块）。
+ */
+export function submoduleFullName(url: string): string | null {
+  const trimmed = url.trim()
+  if (!trimmed) return null
+  for (const pattern of GITHUB_SUBMODULE_URL_PATTERNS) {
+    const match = pattern.exec(trimmed)
+    if (!match) continue
+    const fullName = `${match[1]}/${match[2]}`
+    if (isSafeRepositoryName(fullName)) return fullName
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// gitlink 精确 commit 解析（best-effort）
+// ---------------------------------------------------------------------------
+
+const GITHUB_API_HEADERS = {
+  Accept: 'application/vnd.github+json',
+  'User-Agent': 'DSH-Launcher',
+  'X-GitHub-Api-Version': '2022-11-28',
+}
+
+interface GitTreeResponse {
+  truncated?: boolean
+  tree?: Array<{ path?: string; type?: string; sha?: string }>
+}
+
+function githubTreeUrl(repository: string): string {
+  const [owner, name] = repository.split('/')
+  return `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/git/trees/HEAD?recursive=1`
+}
+
+/**
+ * 最佳努力解析 meta-repo 顶层 gitlink（子模块）的精确 commit。GitHub archive
+ * 快照不含 .git，gitlink 的 SHA 只存在于 git trees API：`type: "commit"` 条目
+ * 即子模块，sha 为父仓库钉住的 commit。失败或树被截断返回 null，调用方回退到
+ * 子模块默认分支。
+ */
+async function resolveSubmodulePins(repository: string, fetchImpl: typeof fetch): Promise<Map<string, string> | null> {
+  try {
+    const response = await fetchImpl(githubTreeUrl(repository), { headers: GITHUB_API_HEADERS })
+    if (!response.ok) return null
+    const body = await response.json() as GitTreeResponse
+    if (body.truncated) return null
+    const pins = new Map<string, string>()
+    for (const entry of body.tree ?? []) {
+      if (entry.type === 'commit' && entry.path && entry.sha && /^[a-f0-9]{40}$/i.test(entry.sha)) {
+        pins.set(entry.path, entry.sha)
+      }
+    }
+    return pins.size > 0 ? pins : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * 下载单个子模块压缩包。优先精确 commit（codeload 直接支持 40 位 SHA）；
+ * 无 pin 时依次尝试 main / master 分支。所有候选都失败才抛错。
+ */
+async function readSubmoduleArchive(
+  repository: string,
+  revisions: string[],
+  onProgress?: (received: number, total: number | null) => void,
+  fetchImpl?: typeof fetch,
+): Promise<Buffer> {
+  let lastError: unknown = new Error('子模块下载失败。')
+  for (const revision of revisions) {
+    try {
+      if (fetchImpl) {
+        const response = await fetchImpl(githubArchiveUrl(repository, revision), {
+          headers: { 'User-Agent': 'DSH-Launcher' },
+        })
+        return await readArchiveResponse(response, onProgress)
+      }
+      return await downloadGitHubArchive(repository, revision, MAX_ARCHIVE_BYTES, onProgress)
+    } catch (error) {
+      lastError = error
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error('子模块下载失败。')
+}
+
+// ---------------------------------------------------------------------------
+// 安全解压
+// ---------------------------------------------------------------------------
+
+/**
+ * 把单个压缩包安全解压到 destinationRoot。要求压缩包是单一根目录结构
+ * （GitHub codeload 快照形式），根目录被剥离，内容写入 destinationRoot。
+ * budget 在多次解压间共享，累计限制文件数与解压体积。
+ */
+async function unpackArchive(
+  archiveBuffer: Buffer,
+  destinationRoot: string,
+  budget: UnpackBudget,
+): Promise<number> {
+  const entries = new AdmZip(archiveBuffer).getEntries()
+  if (entries.length === 0) throw new Error('AI 研究仓库压缩包为空。')
+  let archiveRoot: string | null = null
+  let copiedFiles = 0
+  const resolvedRoot = path.resolve(destinationRoot)
+  for (const entry of entries) {
+    const archivePath = safeArchivePath(entry.entryName)
+    if (!archivePath) throw new Error('AI 研究仓库压缩包包含不安全路径。')
+    const root = archivePath.split('/')[0]
+    if (!archiveRoot) archiveRoot = root
+    if (root !== archiveRoot) throw new Error('AI 研究仓库压缩包结构无效。')
+    if (entry.isDirectory) continue
+
+    const relativePath = archivePath.slice(root.length + 1)
+    if (!relativePath) continue
+    const safeRelative = safeArchivePath(relativePath)
+    if (!safeRelative) throw new Error('AI 研究仓库包含不安全路径。')
+    if (budget.files + 1 > MAX_FILES) throw new Error('仓库文件数量超过安全限制，已停止 AI 研究。')
+    const declaredBytes = Number(entry.header.size) || 0
+    if (budget.bytes + declaredBytes > MAX_UNPACKED_BYTES) {
+      throw new Error('仓库解压体积超过安全限制，已停止 AI 研究。')
+    }
+    const data = entry.getData()
+    if (budget.bytes + data.byteLength > MAX_UNPACKED_BYTES) {
+      throw new Error('仓库解压体积超过安全限制，已停止 AI 研究。')
+    }
+    const outputPath = path.join(destinationRoot, ...safeRelative.split('/'))
+    const resolvedOutput = path.resolve(outputPath)
+    if (!resolvedOutput.startsWith(`${resolvedRoot}${path.sep}`)) {
+      throw new Error('AI 研究仓库文件超出了允许范围。')
+    }
+    await mkdir(path.dirname(outputPath), { recursive: true })
+    await writeFile(outputPath, data)
+    budget.files += 1
+    budget.bytes += data.byteLength
+    copiedFiles += 1
+  }
+  if (!archiveRoot || copiedFiles === 0) throw new Error('AI 研究仓库压缩包为空。')
+  return copiedFiles
+}
+
+// ---------------------------------------------------------------------------
+// 入口
+// ---------------------------------------------------------------------------
+
 /**
  * Download and safely unpack a public GitHub repository into a temporary
  * directory inside DSH_HOME. The AI reads this local copy, so repository
  * inspection does not depend on its shell/network channel.
+ *
+ * 聚合仓库（git submodules）：GitHub archive 快照不含 .git、子模块目录为空。
+ * 这里解析 .gitmodules，把每个 GitHub 托管的子模块内容也预取到对应子目录
+ * （精确 commit 优先，回退默认分支），让 AI 能研究到真正的可安装组件。
  */
 export async function prepareAiRepositorySource(
   sourceRoot: string,
@@ -64,6 +284,7 @@ export async function prepareAiRepositorySource(
   revision: string,
   onProgress?: (received: number, total: number | null) => void,
   fetchImpl?: typeof fetch,
+  onLog?: (text: string) => void,
 ): Promise<AiRepositorySource> {
   if (!isSafeRepositoryName(repository) || !safeRevision(revision)) {
     throw new Error('AI 研究仓库或分支名称无效。')
@@ -72,50 +293,52 @@ export async function prepareAiRepositorySource(
   const taskRoot = await mkdtemp(path.join(sourceRoot, 'session-'))
   const repositoryPath = path.join(taskRoot, 'repository')
   try {
-    const archiveBuffer = fetchImpl
+    const budget: UnpackBudget = { files: 0, bytes: 0 }
+    const mainArchive = fetchImpl
       ? await readArchiveResponse(await fetchImpl(githubArchiveUrl(repository, revision), {
         headers: { 'User-Agent': 'DSH-Launcher' },
       }), onProgress)
       : await downloadGitHubArchive(repository, revision, MAX_ARCHIVE_BYTES, onProgress)
-    const entries = new AdmZip(archiveBuffer).getEntries()
-    if (entries.length > MAX_FILES) throw new Error('仓库文件数量超过安全限制，已停止 AI 研究。')
+    await unpackArchive(mainArchive, repositoryPath, budget)
 
-    let archiveRoot: string | null = null
-    let unpackedBytes = 0
-    let copiedFiles = 0
-    for (const entry of entries) {
-      const archivePath = safeArchivePath(entry.entryName)
-      if (!archivePath) throw new Error('AI 研究仓库压缩包包含不安全路径。')
-      const root = archivePath.split('/')[0]
-      if (!archiveRoot) archiveRoot = root
-      if (root !== archiveRoot) throw new Error('AI 研究仓库压缩包结构无效。')
-      if (entry.isDirectory) continue
-
-      const relativePath = archivePath.slice(root.length + 1)
-      if (!relativePath) continue
-      const safeRelative = safeArchivePath(relativePath)
-      if (!safeRelative) throw new Error('AI 研究仓库包含不安全路径。')
-      copiedFiles += 1
-      const declaredBytes = Number(entry.header.size) || 0
-      if (unpackedBytes + declaredBytes > MAX_UNPACKED_BYTES) {
-        throw new Error('仓库解压体积超过安全限制，已停止 AI 研究。')
+    const submodules: SubmoduleInfo[] = []
+    const skippedSubmodules: { path: string; reason: string }[] = []
+    const gitmodulesPath = path.join(repositoryPath, '.gitmodules')
+    if (existsSync(gitmodulesPath)) {
+      const declarations = parseGitModules(await readFile(gitmodulesPath, 'utf8'))
+      if (declarations.length > 0) {
+        onLog?.(`检测到 ${declarations.length} 个 git 子模块，正在预取…`)
+        const pins = fetchImpl ? await resolveSubmodulePins(repository, fetchImpl) : null
+        const seen = new Set<string>()
+        for (const declaration of declarations) {
+          const submodulePath = safeArchivePath(declaration.path)
+          if (!submodulePath || submodulePath === '.' || submodulePath === '..' || seen.has(submodulePath)) {
+            skippedSubmodules.push({ path: declaration.path, reason: '子模块路径无效或重复' })
+            continue
+          }
+          seen.add(submodulePath)
+          const submoduleRepository = submoduleFullName(declaration.url)
+          if (!submoduleRepository) {
+            skippedSubmodules.push({ path: submodulePath, reason: '非 GitHub 子模块，未预取' })
+            continue
+          }
+          const pinned = pins?.get(submodulePath)
+          const revisions = pinned ? [pinned] : ['main', 'master']
+          try {
+            const submoduleArchive = await readSubmoduleArchive(submoduleRepository, revisions, undefined, fetchImpl)
+            await unpackArchive(submoduleArchive, path.join(repositoryPath, ...submodulePath.split('/')), budget)
+            const resolvedRevision = pinned ?? revisions[0]
+            submodules.push({ path: submodulePath, repository: submoduleRepository, revision: resolvedRevision })
+            onLog?.(`已预取子模块 ${submodulePath} ← ${submoduleRepository}（${resolvedRevision.slice(0, 12)}）`)
+          } catch (error) {
+            const message = error instanceof Error ? error.message : '未知错误'
+            skippedSubmodules.push({ path: submodulePath, reason: `预取失败：${message}` })
+            onLog?.(`跳过子模块 ${submodulePath}：${message}`)
+          }
+        }
       }
-      const data = entry.getData()
-      unpackedBytes += data.byteLength
-      if (copiedFiles > MAX_FILES || unpackedBytes > MAX_UNPACKED_BYTES) {
-        throw new Error('仓库解压体积超过安全限制，已停止 AI 研究。')
-      }
-      const outputPath = path.join(repositoryPath, ...safeRelative.split('/'))
-      const resolvedRoot = path.resolve(repositoryPath)
-      const resolvedOutput = path.resolve(outputPath)
-      if (!resolvedOutput.startsWith(`${resolvedRoot}${path.sep}`)) {
-        throw new Error('AI 研究仓库文件超出了允许范围。')
-      }
-      await mkdir(path.dirname(outputPath), { recursive: true })
-      await writeFile(outputPath, data)
     }
-    if (!archiveRoot || copiedFiles === 0) throw new Error('AI 研究仓库压缩包为空。')
-    return { taskRoot, repositoryPath }
+    return { taskRoot, repositoryPath, submodules, skippedSubmodules }
   } catch (error) {
     await rm(taskRoot, { recursive: true, force: true }).catch(() => undefined)
     throw error

--- a/electron/plugin-catalog.ts
+++ b/electron/plugin-catalog.ts
@@ -25,7 +25,7 @@ interface PackageManifest {
 
 interface GitHubTree {
   truncated?: boolean
-  tree?: Array<{ path: string; type: 'blob' | 'tree' }>
+  tree?: Array<{ path: string; type: 'blob' | 'tree' | 'commit' }>
 }
 
 const GITHUB_HEADERS = {
@@ -354,6 +354,23 @@ export async function analyzeRepository(
         ? `检测到可安装的 ${installTargets[0].packageName}。`
         : `检测到 ${installTargets.length} 个可安装组件，请选择需要的组件。`,
       targets: installTargets,
+    }
+  }
+
+  // git tree 里 type === 'commit' 的条目是 gitlink（git submodule）。GitHub archive
+  // 快照不含子模块内容，真正可安装的组件在子模块里，归类为应用/源码工作区，
+  // 提示用户走「AI 尝试」（启动器会预取子模块内容）。
+  const submodulePaths = entries
+    .filter(entry => entry.type === 'commit')
+    .map(entry => entry.path)
+    .slice(0, 8)
+  if (submodulePaths.length > 0) {
+    return {
+      repository,
+      defaultBranch,
+      installability: 'application',
+      summary: `这是聚合仓库（meta-repo），含 ${submodulePaths.length} 个子模块（${submodulePaths.join('、')}）。子模块才是可安装组件，请用「AI 尝试」研究并安装。`,
+      targets: [],
     }
   }
 

--- a/tests/ai-install.test.ts
+++ b/tests/ai-install.test.ts
@@ -150,6 +150,25 @@ describe('buildInstallPrompt', () => {
     expect(prompt).toContain('每次 PowerShell 命令都必须等待启动器审批')
     expect(prompt).toContain('不要使用后台任务')
   })
+
+  it('meta-repo：列出已预取子模块与跳过原因，引导 AI 检查子模块目录', () => {
+    const prompt = buildInstallPrompt({
+      ...base,
+      analysis: analysis('application', '聚合仓库'),
+      repositoryPath: '/home/tester/.dsh/.ai-install-sources/session-1/repository',
+      submodules: [
+        { path: 'injector', repository: 'yjh051108/dsh-super-injector', revision: 'c'.repeat(40) },
+        { path: 'mode-boost', repository: 'yjh051108/dsh-mode-boost', revision: 'main' },
+      ],
+      skippedSubmodules: [{ path: 'preset', reason: '非 GitHub 子模块，未预取' }],
+    })
+    expect(prompt).toContain('聚合仓库')
+    expect(prompt).toContain('injector/')
+    expect(prompt).toContain('yjh051108/dsh-super-injector')
+    expect(prompt).toContain('yjh051108/dsh-mode-boost')
+    expect(prompt).toContain('非 GitHub 子模块，未预取')
+    expect(prompt).toContain('请勿尝试联网下载')
+  })
 })
 
 describe('AI 故障修复提示词', () => {

--- a/tests/ai-repository-source.test.ts
+++ b/tests/ai-repository-source.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import AdmZip from 'adm-zip'
 import { describe, expect, it } from 'vitest'
-import { prepareAiRepositorySource } from '../electron/ai-repository-source'
+import { parseGitModules, prepareAiRepositorySource, submoduleFullName } from '../electron/ai-repository-source'
 
 function archive(entries: Record<string, string>): Buffer {
   const zip = new AdmZip()
@@ -60,6 +60,212 @@ describe('prepareAiRepositorySource', () => {
         archiveFetch(buffer),
       )).rejects.toThrow(/不安全路径|结构无效/)
       expect(existsSync(path.join(root, 'escape.txt'))).toBe(false)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// .gitmodules 解析
+// ---------------------------------------------------------------------------
+
+describe('parseGitModules', () => {
+  it('解析 path/url/branch，忽略注释与其它段', () => {
+    const content = [
+      '# 这是注释',
+      '[submodule "injector"]',
+      '\tpath = injector',
+      '\turl = https://github.com/a/dsh-super-injector.git',
+      '\tbranch = v0.3.3',
+      '',
+      '[submodule "preset"]',
+      '  path = preset',
+      '  url = git@github.com:b/dsh-router-standard.git',
+      '',
+      '[some "other"]',
+      '\tkey = value',
+    ].join('\n')
+    expect(parseGitModules(content)).toEqual([
+      { name: 'injector', path: 'injector', url: 'https://github.com/a/dsh-super-injector.git', branch: 'v0.3.3' },
+      { name: 'preset', path: 'preset', url: 'git@github.com:b/dsh-router-standard.git' },
+    ])
+  })
+
+  it('丢弃缺 path 或 url 的声明', () => {
+    expect(parseGitModules('[submodule "x"]\n\turl = https://github.com/a/b.git\n')).toEqual([])
+    expect(parseGitModules('[submodule "y"]\n\tpath = y\n')).toEqual([])
+  })
+
+  it('CRLF 换行也能解析', () => {
+    expect(parseGitModules('[submodule "z"]\r\n\tpath = z\r\n\turl = https://github.com/a/z.git\r\n'))
+      .toEqual([{ name: 'z', path: 'z', url: 'https://github.com/a/z.git' }])
+  })
+})
+
+describe('submoduleFullName', () => {
+  it('识别各类 GitHub URL', () => {
+    expect(submoduleFullName('https://github.com/a/b')).toBe('a/b')
+    expect(submoduleFullName('https://github.com/a/b.git')).toBe('a/b')
+    expect(submoduleFullName('git@github.com:a/b.git')).toBe('a/b')
+    expect(submoduleFullName('ssh://git@github.com/a/b.git')).toBe('a/b')
+    expect(submoduleFullName('git+https://github.com/a/b.git')).toBe('a/b')
+    expect(submoduleFullName('github:a/b')).toBe('a/b')
+  })
+
+  it('拒绝非 GitHub / 畸形 URL', () => {
+    expect(submoduleFullName('https://gitlab.com/a/b.git')).toBeNull()
+    expect(submoduleFullName('git@gitlab.com:a/b.git')).toBeNull()
+    expect(submoduleFullName('https://github.com/a')).toBeNull()
+    expect(submoduleFullName('https://github.com/a/b/c')).toBeNull()
+    expect(submoduleFullName('https://example.com/a/b')).toBeNull()
+    expect(submoduleFullName('')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// meta-repo：git 子模块预取
+// ---------------------------------------------------------------------------
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), { status: 200 })
+}
+
+function bufferResponse(buffer: Buffer): Response {
+  return new Response(Uint8Array.from(buffer).buffer, {
+    status: 200,
+    headers: { 'content-length': String(buffer.length) },
+  })
+}
+
+/** 按 URL 子串路由的 fetch mock；每个 URL 由工厂生成全新 Response（body 不可复用）。 */
+function routingFetch(routes: Record<string, () => Response>): typeof fetch {
+  return (async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : String(input)
+    for (const [marker, factory] of Object.entries(routes)) {
+      if (url.includes(marker)) return factory()
+    }
+    throw new Error(`unexpected fetch: ${url}`)
+  }) as typeof fetch
+}
+
+describe('prepareAiRepositorySource 预取 git 子模块', () => {
+  it('meta-repo：把 .gitmodules 声明的 GitHub 子模块内容解压到对应子目录（用 gitlink 精确 commit）', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'dsh-ai-source-meta-'))
+    try {
+      const mainBuffer = archive({
+        'repo-meta/.gitmodules': [
+          '[submodule "injector"]',
+          '\tpath = injector',
+          '\turl = https://github.com/yjh051108/dsh-super-injector.git',
+          '[submodule "mode-boost"]',
+          '\tpath = mode-boost',
+          '\turl = git@github.com:yjh051108/dsh-mode-boost.git',
+        ].join('\n'),
+        'repo-meta/README.md': '# routing suite',
+      })
+      const injectorBuffer = archive({
+        'dsh-super-injector-main/package.json': '{"name":"dsh-super-injector"}',
+        'dsh-super-injector-main/src/index.ts': 'export const inject = true\n',
+      })
+      const modeBoostBuffer = archive({
+        'dsh-mode-boost-main/package.json': '{"name":"dsh-mode-boost"}',
+      })
+      const injectorSha = 'c'.repeat(40)
+      const modeBoostSha = 'd'.repeat(40)
+      const fetchImpl = routingFetch({
+        'dsh-routing-suite/zip': () => bufferResponse(mainBuffer),
+        'git/trees': () => jsonResponse({
+          truncated: false,
+          tree: [
+            { path: '.gitmodules', type: 'blob', sha: 'a'.repeat(40) },
+            { path: 'injector', type: 'commit', sha: injectorSha },
+            { path: 'mode-boost', type: 'commit', sha: modeBoostSha },
+          ],
+        }),
+        'dsh-super-injector/zip': () => bufferResponse(injectorBuffer),
+        'dsh-mode-boost/zip': () => bufferResponse(modeBoostBuffer),
+      })
+      const logs: string[] = []
+      const source = await prepareAiRepositorySource(
+        root,
+        'yjh051108/dsh-routing-suite',
+        'main',
+        undefined,
+        fetchImpl,
+        text => logs.push(text),
+      )
+
+      expect(await readFile(path.join(source.repositoryPath, 'README.md'), 'utf8')).toContain('routing suite')
+      // 子模块内容预取到对应子目录
+      expect(await readFile(path.join(source.repositoryPath, 'injector', 'package.json'), 'utf8')).toContain('dsh-super-injector')
+      expect(await readFile(path.join(source.repositoryPath, 'injector', 'src', 'index.ts'), 'utf8')).toContain('inject')
+      expect(await readFile(path.join(source.repositoryPath, 'mode-boost', 'package.json'), 'utf8')).toContain('dsh-mode-boost')
+      expect(source.submodules).toEqual([
+        { path: 'injector', repository: 'yjh051108/dsh-super-injector', revision: injectorSha },
+        { path: 'mode-boost', repository: 'yjh051108/dsh-mode-boost', revision: modeBoostSha },
+      ])
+      expect(source.skippedSubmodules).toEqual([])
+      expect(logs.some(text => text.includes('子模块'))).toBe(true)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('meta-repo：非 GitHub 子模块跳过并在 skippedSubmodules 记录原因', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'dsh-ai-source-skip-'))
+    try {
+      const mainBuffer = archive({
+        'repo-meta/.gitmodules': [
+          '[submodule "ext"]',
+          '\tpath = ext',
+          '\turl = https://gitlab.com/group/lib.git',
+          '[submodule "ok"]',
+          '\tpath = ok',
+          '\turl = https://github.com/acme/ok-plugin.git',
+        ].join('\n'),
+        'repo-meta/README.md': '# meta',
+      })
+      const okBuffer = archive({ 'ok-plugin-main/package.json': '{"name":"ok-plugin"}' })
+      const fetchImpl = routingFetch({
+        'repo-meta/zip': () => bufferResponse(mainBuffer),
+        'git/trees': () => jsonResponse({ truncated: false, tree: [] }),
+        'ok-plugin/zip': () => bufferResponse(okBuffer),
+      })
+
+      const source = await prepareAiRepositorySource(root, 'acme/repo-meta', 'main', undefined, fetchImpl)
+
+      expect(source.submodules).toEqual([{ path: 'ok', repository: 'acme/ok-plugin', revision: 'main' }])
+      expect(source.skippedSubmodules).toEqual([{ path: 'ext', reason: '非 GitHub 子模块，未预取' }])
+      // 非 GitHub 子模块未下载内容
+      expect(existsSync(path.join(source.repositoryPath, 'ext'))).toBe(false)
+      expect(await readFile(path.join(source.repositoryPath, 'ok', 'package.json'), 'utf8')).toContain('ok-plugin')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('meta-repo：子模块下载失败时跳过并记录原因，不阻断整体', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'dsh-ai-source-fail-'))
+    try {
+      const mainBuffer = archive({
+        'repo-meta/.gitmodules': '[submodule "missing"]\n\tpath = missing\n\turl = https://github.com/acme/missing.git\n',
+        'repo-meta/README.md': '# meta',
+      })
+      const fetchImpl = routingFetch({
+        'repo-meta/zip': () => bufferResponse(mainBuffer),
+        // 无 missing/zip 路由 → readSubmoduleArchive 对每个候选 revision 都失败
+        'git/trees': () => jsonResponse({
+          truncated: false,
+          tree: [{ path: 'missing', type: 'commit', sha: 'e'.repeat(40) }],
+        }),
+      })
+
+      const source = await prepareAiRepositorySource(root, 'acme/repo-meta', 'main', undefined, fetchImpl)
+
+      expect(source.submodules).toEqual([])
+      expect(source.skippedSubmodules).toEqual([expect.objectContaining({ path: 'missing' })])
+      expect(source.skippedSubmodules[0].reason).toMatch(/预取失败/)
     } finally {
       await rm(root, { recursive: true, force: true })
     }


### PR DESCRIPTION
## 背景

`AI 尝试安装` 对 `https://github.com/yjh051108/dsh-routing-suite` 失败。根因：该仓库是 git 子模块聚合仓库（meta-repo），启动器下载的是 GitHub codeload 归档快照——不含 `.git`、`gitlink` 对应的子模块目录（`injector` / `preset` / `mode-boost`）到达本地为空，AI 的约束又禁止它自行 clone/下载，因此研究时找不到任何可装组件。

## 改动

1. **`electron/ai-repository-source.ts` — 子模块预取**
   - 新增 `parseGitModules`（解析 `.gitmodules` 的 path/url/branch）与 `submoduleFullName`（只认 GitHub 托管 URL，其余拒绝）。
   - 经 `git/trees/HEAD?recursive=1` API best-effort 解析 gitlink 精确 commit，失败回退 `main` → `master`，确保安装 meta-repo 钉住的版本。
   - 逐个下载 GitHub 子模块归档并安全解压到对应子目录；文件数/解压体积预算改为主仓库+子模块**共享累计**（比原先单包各自限额更严）。
   - 非 GitHub / 下载失败子模块跳过并记录原因，不阻断整体。
   - 返回 `submodules` + `skippedSubmodules` 元数据。

2. **`electron/ai-install.ts` — 提示词注入**：新增「聚合仓库（git submodules）」章节，明确列出每个子模块目录、对应仓库与 revision，引导 AI 逐个检查子模块目录里的 Bundle/Skill；跳过项提示「目录为空，勿尝试联网下载」。

3. **`electron/plugin-catalog.ts` — 市场分析识别 meta-repo**：git tree 中 `type === 'commit'` 的条目即 gitlink；检测到即归类为 `application`（恰好触发「AI 尝试」按钮），摘要说明「聚合仓库，子模块才是可安装组件」。

## 安全边界（未削弱）

子模块下载全部走启动器自己的 codeload 流程（https、单包 64MB、路径穿越防护、累计预算）；只接受 GitHub 托管 URL；git trees API 只读且复用现有 GitHub fetch。AI 依旧没有任何联网/download 通道——仍为「启动器预取 → AI 读本地副本」。凭据锁、sandbox+ask 审批、快照/回滚、互斥、超时均未改动。

## 验证

- `npx tsc --noEmit` 通过
- `npx vitest run`：37 文件 / 393 测试通过（6 个平台感知跳过，与 CI 双矩阵一致）
- 新增 15 个测试：`.gitmodules` 全形式解析、子模块 URL 接受/拒绝、meta-repo 端到端（子模块内容落盘 + 精确 commit 元数据）、非 GitHub/下载失败跳过、提示词聚合仓库章节

## 附注（存量问题，随本 PR 一并修复）

v0.1.7 拉入的 `react-markdown` / `remark-gfm`（AI 渲染）在 `package.json` 声明但从未安装，导致 `tsc --noEmit` 报缺模块错误；已 `npm install` 补装，锁文件无额外改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)