### PR TITLE
fix(update): 便携版自更新使用 PORTABLE_EXECUTABLE_FILE 定位原 exe

### DIFF
--- a/electron/launcher-update.ts
+++ b/electron/launcher-update.ts
@@ -277,7 +277,7 @@ export function createLauncherUpdater(options: LauncherUpdaterOptions): Launcher
       throw new Error('没有已下载的启动器更新。')
     }
     const target = pending as PendingUpdate
-    const execPath = (options.getExecPath ?? (() => process.execPath))()
+    const execPath = (options.getExecPath ?? (() => process.env.PORTABLE_EXECUTABLE_FILE || process.execPath))()
     const execBase = path.basename(execPath)
     const tempPath = path.join(updateRoot, target.asset.name)
     const scriptPath = path.join(updateRoot, `apply-${process.pid}.cmd`)


### PR DESCRIPTION
## 问题

便携版点击“立即更新”后：

- 旧启动器退出了
- 但新版本没有自动打开
- 原因是 `process.execPath` 在 electron-builder portable 中指向**解压后的临时 exe**
- 脚本替换的是临时 exe，而不是用户双击的那个 portable 原文件，因此替换/重启不生效

## 修复

- 获取可执行文件路径时优先使用：

```js
process.env.PORTABLE_EXECUTABLE_FILE
```

- 该变量由 electron-builder portable 注入，指向真正的便携版 exe
- 不存在时回退到 `process.execPath`

## 验证

- `npx tsc --noEmit` 通过
- `launcher-update.test.ts` 16/16 通过