### PR TITLE
fix(install): Release tgz 持久保留，避免 file: 依赖指向已删除临时文件

### DIFF
--- a/electron/installer.ts
+++ b/electron/installer.ts
@@ -695,15 +695,18 @@ export function createInstaller(options: InstallerOptions): Installer {
           specifier = `github:${fullName}#${target.commit}`
         } else if (target.source === 'release') {
           // 源码 pin 不一定带构建产物，Release tgz 是官方安装包：下载后 `dsh plugin add file:<tgz>`。
+          // tgz 会作为 file: 依赖写入 Profile package.json，必须放在持久目录且不能删除，
+          // 否则后续 pnpm 操作会因找不到临时文件而失败（ENOENT）。
           if (!target.tarballUrl) throw new Error('Release 插件缺少下载地址。')
-          const tgzPath = path.join(options.pluginSourceRoot, `.release-${process.pid}-${Date.now()}.tgz`)
+          const safePackageName = target.packageName.replace(/[^a-z0-9._-]+/gi, '-')
+          const tgzName = `${safePackageName}-${target.version ?? target.commit}.tgz`
+          const tgzPath = path.join(options.pluginSourceRoot, tgzName)
           await mkdir(options.pluginSourceRoot, { recursive: true })
           emit({ repository: fullName, kind: 'plugin', phase: 'downloading', percent: 30, message: '正在下载 Release 安装包' })
           const asset = options.githubFetch
             ? await downloadReleaseAsset(target.tarballUrl, MAX_RELEASE_BYTES, undefined, options.githubFetch)
             : await downloadReleaseAsset(target.tarballUrl, MAX_RELEASE_BYTES)
-          await writeFile(tgzPath, asset, { flag: 'wx' })
-          temporaryArtifacts.push(tgzPath)
+          await writeFile(tgzPath, asset)
           specifier = `file:${tgzPath}`
         } else if (target.source === 'local-directory') {
           specifier = `file:${validateLocalPluginDirectory(target.localDirectory)}`

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -563,7 +563,7 @@ describe('installPluginTarget release 源（meta-repo tgz 直链）', () => {
     }
   }
 
-  it('请求带 tarballUrl 时下载官方 tgz 并用 `add file:<tgz>` 安装，装完删除临时包', async () => {
+  it('请求带 tarballUrl 时下载官方 tgz 并用 `add file:<tgz>` 安装，tgz 持久保留', async () => {
     vi.mocked(analyzeRepository).mockResolvedValue({
       repository: 'yjh051108/dsh-super-injector',
       defaultBranch: 'main',
@@ -593,8 +593,8 @@ describe('installPluginTarget release 源（meta-repo tgz 直链）', () => {
     expect(fileSpecifier!.endsWith('.tgz')).toBe(true)
     const tgzPath = fileSpecifier!.slice('file:'.length)
     expect(tgzPath.startsWith(path.join(temporaryDirectory, 'plugin-source'))).toBe(true)
-    // 临时 tgz 装完即删（finally 清理）。
-    await expect(access(tgzPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    // tgz 是 file: 依赖的持久来源，装完后必须保留，否则后续 pnpm 操作会 ENOENT。
+    await expect(access(tgzPath)).resolves.toBeUndefined()
     expect(recordPluginInstall).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({ packageName: 'demo-plugin', source: 'release' }),


### PR DESCRIPTION
## 问题

通过 Release tgz 安装插件后，DSH Profile 的 `package.json` 里会写入：

```json
@dsh-external/dsh-super-injector: file:<临时目录>/xxx.tgz
```

但启动器安装完会删除这个临时 tgz，导致之后所有 pnpm 插件操作都报：

```text
ENOENT: no such file or directory, open '<临时目录>/xxx.tgz'
```

## 修复

- Release tgz 改为写入 `pluginSourceRoot` 下的稳定文件名：

```text
<pluginSourceRoot>/<safe-package-name>-<version>.tgz
```

- 安装后**不再删除**该 tgz；
- 这样 `file:` 依赖始终指向持久存在的文件，后续 pnpm 操作不会再 ENOENT。

## 验证

- `npx tsc --noEmit` 通过
- `installer.test.ts` 28/28 通过