### PR TITLE
fix(install): 自动批准 pnpm 报告的全部被忽略构建脚本

### DIFF
--- a/electron/installer.ts
+++ b/electron/installer.ts
@@ -37,7 +37,7 @@ import {
 } from './dsh-install'
 import { checkDshUpdate } from './dsh-update'
 import { resolveNodeExecutable, type NodeRuntime, type NodeRuntimeProgress, type PnpmRuntime } from './node-runtime'
-import { approveBuildKeys, approveIgnoredGitHubBuilds, denyBuildKeys, ignoredBuildKeys } from './plugin-install'
+import { approveAllIgnoredBuilds, denyBuildKeys } from './plugin-install'
 import { analyzeMetaRepository } from './meta-repo-catalog'
 import { analyzeRepository } from './plugin-catalog'
 import { prepareSubdirectoryPlugin, type PluginSourceProgress } from './plugin-source'
@@ -454,15 +454,13 @@ export function createInstaller(options: InstallerOptions): Installer {
       throw new Error(`插件依赖迁移失败（代码 ${migrate.exitCode}），请查看运行日志。`)
     }
 
-    // pnpm 默认拒绝执行依赖里的构建脚本。只为当前正在安装的仓库放行，然后重试一次。
+    // pnpm 默认拒绝执行依赖里的构建脚本。这里等价于 `pnpm approve-builds`，
+    // 批准 pnpm 报告的全部被忽略构建脚本后自动重试一次。
     if (result.exitCode !== 0 && installingRepository && allowBuildRetry && result.output.includes('ERR_PNPM_IGNORED_BUILDS')) {
       const workspacePath = path.join(settings.dshHome, 'profiles', targetProfile, 'pnpm-workspace.yaml')
-      const approved = await approveIgnoredGitHubBuilds(workspacePath, result.output, installingRepository)
-      const declared = new Set(approvedRegistryBuildKeys)
-      const registryKeys = ignoredBuildKeys(result.output).filter(key => declared.has(key))
-      approved.push(...await approveBuildKeys(workspacePath, registryKeys))
+      const approved = await approveAllIgnoredBuilds(workspacePath, result.output)
       if (approved.length > 0) {
-        options.emitOutput('info', `已允许当前插件清单声明的 ${approved.length} 个构建脚本，正在自动重试。`)
+        options.emitOutput('info', `已允许 ${approved.length} 个被忽略的构建脚本，正在自动重试。`)
         emit({
           repository: installingRepository,
           kind: 'plugin',

--- a/electron/plugin-install.ts
+++ b/electron/plugin-install.ts
@@ -28,6 +28,11 @@ export async function approveIgnoredGitHubBuilds(
   return approveBuildKeys(workspacePath, matchingKeys)
 }
 
+/** 批准 pnpm 报告的全部被忽略构建脚本（等价于 `pnpm approve-builds`）。 */
+export async function approveAllIgnoredBuilds(workspacePath: string, output: string): Promise<string[]> {
+  return approveBuildKeys(workspacePath, ignoredBuildKeys(output))
+}
+
 export async function approveBuildKeys(workspacePath: string, buildKeys: string[]): Promise<string[]> {
   return setBuildKeys(workspacePath, buildKeys, true)
 }


### PR DESCRIPTION
## 问题

安装部分插件时，pnpm 会报：

```text
ERR_PNPM_IGNORED_BUILDS
Ignored build scripts: cloudflared@0.7.3, cpu-features@0.0.10, node-pty@1.1.0, ssh2@1.17.0
```

启动器之前只批准与当前 GitHub 仓库匹配的构建脚本，导致这些依赖的构建脚本没有被批准，DSH 插件安装失败。

## 修复

- 新增 `approveAllIgnoredBuilds`：
  - 解析 pnpm 输出的所有 `Ignored build scripts`
  - 写入 `pnpm-workspace.yaml` 的 `allowBuilds`
- `installPluginTarget` 遇到 `ERR_PNPM_IGNORED_BUILDS` 时：
  - 批准全部被忽略脚本
  - 自动重试一次

## 验证

- `npx tsc --noEmit` 通过
- `installer.test.ts` 28/28 通过
- `plugin-install.test.ts` 4/4 通过