### PR TITLE
fix(pack): allow deleting inactive packs while DSH runtime is running

### DIFF
--- a/electron/pack.ts
+++ b/electron/pack.ts
@@ -1134,12 +1134,18 @@ export function createPackManager(options: PackManagerOptions): PackManager {
     },
 
     async removePack(packId) {
-      const reason = guarded()
+      const settings = await options.readSettings()
+      const reason = settings.activePackId === packId
+        ? guarded()
+        : guardPackStart({
+            isRuntimeRunning: () => false,
+            isInstallerBusy: options.isInstallerBusy,
+            isPackBusy: () => active,
+          })
       if (reason) throw new Error(reason)
       beginTask()
       try {
         const record = await findRecord(packId)
-        const settings = await options.readSettings()
         if (settings.activePackId === packId) {
           await restoreBaseline(settings)
         }

--- a/tests/pack.test.ts
+++ b/tests/pack.test.ts
@@ -749,6 +749,38 @@ describe('analyzeImport', () => {
 })
 
 // ---------------------------------------------------------------------------
+// removePack
+// ---------------------------------------------------------------------------
+
+describe('removePack runtime guard', () => {
+  it('allows deleting an inactive pack while DSH runtime is running', async () => {
+    const env = await makeEnv()
+    const stub = makeInstallerStub()
+    stub.readProfile.mockResolvedValue({ ...defaultProfile, plugins: [managedPlugin('alpha')] })
+    const store = makeSettings(env.dshHome, 'web')
+    const { manager } = makeManager(env, stub, store, { isRuntimeRunning: () => true })
+    await upsertPackRecord(env.registryPath, recordFor('pack-x', [{ packageName: 'alpha', enabled: true }]))
+
+    const result = await manager.removePack('pack-x')
+    expect(result.removed).toBe(1)
+    expect(await readPackRegistry(env.registryPath)).toEqual([])
+  })
+
+  it('still blocks deleting an active pack while DSH runtime is running', async () => {
+    const env = await makeEnv()
+    const stub = makeInstallerStub()
+    stub.readProfile.mockResolvedValue({ ...defaultProfile, plugins: [managedPlugin('alpha')] })
+    const store = makeSettings(env.dshHome, 'web')
+    store.current.activePackId = 'pack-x'
+    const { manager } = makeManager(env, stub, store, { isRuntimeRunning: () => true })
+    await upsertPackRecord(env.registryPath, recordFor('pack-x', [{ packageName: 'alpha', enabled: true }]))
+
+    await expect(manager.removePack('pack-x')).rejects.toThrow('DSH 运行时正在运行')
+    expect(await readPackRegistry(env.registryPath)).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // activate / deactivate
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 问题

整合包点击删除时，即使该整合包并未启用，也会因为 DSH 运行时正在运行而失败，提示“DSH 运行时正在运行”。

原因：`removePack` 复用了 `guarded()`，它把所有整合包操作都视为需要停止运行时。但删除未启用的整合包只涉及移除注册表记录和本地清单，不修改运行中的 Profile，不应被运行时拦截。

## 改动

- `removePack` 先读取当前设置：
  - 删除**未启用**的整合包：跳过运行时守卫，只保留安装器忙 / 整合包操作互斥检查。
  - 删除**启用中**的整合包：仍要求停止 DSH 运行时，因为需要恢复基线插件状态。

## 测试

- 新增 `removePack runtime guard` 两条测试：
  - 运行时运行中可删除未启用整合包。
  - 运行时运行中删除启用中整合包仍被拒绝。
- `npx tsc --noEmit` 通过。
- `tests/pack.test.ts` / `tests/pack-shared-profile.test.ts` 通过。
