### PR TITLE
feat: 系统托盘后台运行与单实例唤起

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 本文件记录 DSH 旋律启动器（dsh-melody-launcher）的版本变更。格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，版本语义遵循 [Semantic Versioning](https://semver.org/lang/zh-CN/)。
 
+## [v0.3.7] - 2026-08-24
+
+### 新增功能
+
+- **系统托盘与后台运行**：新增系统托盘图标（悬停提示「DSH 旋律启动器」），左键单击唤起主窗口，右键菜单提供「显示主窗口」与「退出」。点击标题栏 × 或 Alt+F4 不再结束进程，仅隐藏到托盘继续后台运行（DSH 运行时等子进程不受影响）；首次隐藏时弹一次气泡提示。真正的退出只走托盘右键「退出」，复用既有 `before-quit` 清理链路（停止 DSH 运行时、回收子进程树、还原 AI 凭据锁），并在 `will-quit` 移除托盘图标避免通知区残留。
+- **单实例唤起**：启动时通过 `requestSingleInstanceLock()` 加锁，再次双击 exe 时新进程立即退出，已运行实例收到 `second-instance` 事件后唤起前台窗口（恢复最小化并短暂置顶抢焦点），不再多开。
+
+### 测试
+
+- 全套 569 项测试通过（47 项 e2e 依赖真实环境按惯例跳过），`tsc --noEmit` 与 `vite build` 通过。
+
 ## [v0.3.6] - 2026-08-24
 
 ### 新增功能

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -41,6 +41,7 @@ import { createRendererEvents } from './renderer-events'
 import { createRuntimeController, type RuntimeController } from './runtime'
 import { createRuntimeVersionService, type RuntimeVersionService } from './runtime-versions'
 import { createSettingsStore, defaultSettings, type SettingsStore } from './settings'
+import { createTray, type TrayController } from './tray'
 import { recoverLegacyCredentials } from './dsh-credentials-compat'
 
 /**
@@ -49,11 +50,17 @@ import { recoverLegacyCredentials } from './dsh-credentials-compat'
  */
 
 const moduleDirectory = path.dirname(fileURLToPath(import.meta.url))
+// 窗口图标与托盘图标共用同一资源；dev 取 public/，打包取 dist/。
+const launcherIconPath = path.join(moduleDirectory, app.isPackaged ? '../dist/launcher-icon.png' : '../public/launcher-icon.png')
 
 let mainWindow: BrowserWindow | null = null
 let processSupervisor: ProcessSupervisor | null = null
 let quitCleanupStarted = false
 let allowFinalQuit = false
+// 关闭按钮只隐藏到托盘；before-quit 置位后放行真正的关闭。
+let isQuitting = false
+let tray: TrayController | null = null
+let backgroundNoticeShown = false
 
 const getWindow = (): BrowserWindow | null => mainWindow
 const events = createRendererEvents(createRendererChannel(getWindow))
@@ -558,13 +565,47 @@ function createServices(): Services {
 }
 
 function openMainWindow(): void {
-  mainWindow = createMainWindow({
+  const window = createMainWindow({
     preloadPath: path.join(moduleDirectory, 'preload.mjs'),
-    iconPath: path.join(moduleDirectory, app.isPackaged ? '../dist/launcher-icon.png' : '../public/launcher-icon.png'),
+    iconPath: launcherIconPath,
     devServerUrl: process.env.VITE_DEV_SERVER_URL,
     indexPath: path.join(moduleDirectory, '../dist/index.html'),
     onClosed: () => { mainWindow = null },
   })
+  // 点 X 或 Alt+F4 只隐藏到托盘继续后台运行；托盘菜单「退出」经 app.quit()
+  // 触发 before-quit 置位 isQuitting 后，这里才放行关闭。
+  window.on('close', event => {
+    if (isQuitting) return
+    event.preventDefault()
+    window.hide()
+    if (!backgroundNoticeShown) {
+      backgroundNoticeShown = true
+      tray?.notifyBackground()
+    }
+  })
+  mainWindow = window
+}
+
+/** 从托盘或第二实例唤起主窗口；窗口不存在时重建。 */
+function showMainWindow(): void {
+  const window = getWindow()
+  if (!window || window.isDestroyed()) {
+    openMainWindow()
+    return
+  }
+  if (window.isMinimized()) window.restore()
+  // 无边框透明窗口从后台唤起时常抢不到焦点，短暂置顶可确保激活。
+  window.setAlwaysOnTop(true, 'screen-saver')
+  window.show()
+  window.focus()
+  window.setAlwaysOnTop(false, 'screen-saver')
+}
+
+// 第二个实例直接退出，由已运行实例通过 second-instance 唤起前台窗口。
+if (!app.requestSingleInstanceLock()) {
+  app.quit()
+} else {
+  app.on('second-instance', () => showMainWindow())
 }
 
 app.whenReady().then(async () => {
@@ -588,6 +629,7 @@ app.whenReady().then(async () => {
   })
   await services.profilePoolReady
   openMainWindow()
+  tray = createTray({ iconPath: launcherIconPath, showMainWindow })
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) openMainWindow()
   })
@@ -658,8 +700,16 @@ app.on('before-quit', event => {
   event.preventDefault()
   if (quitCleanupStarted) return
   quitCleanupStarted = true
+  // 放行窗口 close：清理完成后窗口随退出流程正常关闭。
+  isQuitting = true
   void shutdownLauncherProcesses().finally(() => {
     allowFinalQuit = true
     app.quit()
   })
+})
+
+// will-quit 在 before-quit 清理完成后触发，此时移除托盘图标。
+app.on('will-quit', () => {
+  tray?.destroy()
+  tray = null
 })

--- a/electron/tray.ts
+++ b/electron/tray.ts
@@ -1,0 +1,43 @@
+import { Menu, Tray, app } from 'electron'
+
+/**
+ * 系统托盘：左键唤起主窗口，右键菜单提供显示与退出入口。
+ * 关闭按钮只隐藏窗口，「退出」是唯一结束进程的入口。
+ */
+
+export interface TrayController {
+  /** 首次隐藏到托盘时的一次性气泡提示。 */
+  notifyBackground(): void
+  destroy(): void
+}
+
+interface CreateTrayOptions {
+  iconPath: string
+  showMainWindow: () => void
+}
+
+export function createTray(options: CreateTrayOptions): TrayController {
+  const tray = new Tray(options.iconPath)
+  tray.setToolTip('DSH 旋律启动器')
+  tray.setContextMenu(Menu.buildFromTemplate([
+    { label: '显示主窗口', click: () => options.showMainWindow() },
+    { type: 'separator' },
+    { label: '退出', click: () => app.quit() },
+  ]))
+  tray.on('click', () => options.showMainWindow())
+
+  return {
+    notifyBackground() {
+      if (tray.isDestroyed() || process.platform !== 'win32') return
+      tray.displayBalloon({
+        iconType: 'info',
+        title: 'DSH 旋律启动器',
+        content: '程序仍在后台运行，右键托盘图标可退出。',
+      })
+    },
+    destroy() {
+      // 退出前移除图标，避免通知区残留僵尸图标。
+      tray.destroy()
+    },
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-launcher",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "private": true,
   "description": "A local desktop launcher and plugin organizer for DeepSeek Harness.",
   "keywords": [


### PR DESCRIPTION
## 概要

- **系统托盘**：新增托盘图标（悬停提示「DSH 旋律启动器」），左键单击唤起主窗口，右键菜单提供「显示主窗口」与「退出」。
- **关闭到托盘**：点标题栏 × 或 Alt+F4 只隐藏窗口，进程继续后台运行（DSH 运行时等子进程不受影响）；首次隐藏弹气泡提示。真正退出只走托盘右键「退出」，复用既有 `before-quit` 清理链路。
- **单实例唤起**：`requestSingleInstanceLock()` 加锁，重复双击 exe 不再多开，已运行实例收到 `second-instance` 后唤起前台窗口（恢复最小化 + 短暂置顶抢焦点）。

## 变更文件

- 新增 `electron/tray.ts`（托盘模块）
- 修改 `electron/main.ts`（单实例锁、close 拦截、托盘生命周期、showMainWindow）
- 版本号 0.3.7 + CHANGELOG

## 测试

- 全套 569 项测试通过（47 项 e2e 按惯例跳过）
- `tsc --noEmit` 与 `vite build` 通过